### PR TITLE
chore: fix esmodules

### DIFF
--- a/.babel.cjs.json
+++ b/.babel.cjs.json
@@ -1,7 +1,16 @@
 {
   "plugins": [
-    "@babel/transform-modules-commonjs",
-    "@babel/plugin-proposal-export-namespace-from",
-    "annotate-pure-calls"
+    ["@babel/transform-modules-commonjs"],
+    ["@babel/plugin-proposal-export-namespace-from"],
+    ["annotate-pure-calls"],
+    [
+      "transform-rename-import",
+      {
+        "replacements": [
+          { "original": "^fp-ts/(\\w*)$", "replacement": "fp-ts/lib/$1.js" },
+          { "original": "^io-ts/(\\w*)$", "replacement": "io-ts/lib/$1.js" }
+        ]
+      }
+    ]
   ]
 }

--- a/.babel.esm.json
+++ b/.babel.esm.json
@@ -5,8 +5,8 @@
       "transform-rename-import",
       {
         "replacements": [
-          { "original": "^fp-ts/(\\w*)$", "replacement": "fp-ts/lib/$1.js" },
-          { "original": "^io-ts/(\\w*)$", "replacement": "io-ts/lib/$1.js" }
+          { "original": "^fp-ts/(\\w*)$", "replacement": "fp-ts/es6/$1.js" },
+          { "original": "^io-ts/(\\w*)$", "replacement": "io-ts/es6/$1.js" }
         ]
       }
     ]

--- a/.babel.esm.json
+++ b/.babel.esm.json
@@ -1,3 +1,14 @@
 {
-  "plugins": ["annotate-pure-calls"]
+  "plugins": [
+    ["annotate-pure-calls"],
+    [
+      "transform-rename-import",
+      {
+        "replacements": [
+          { "original": "^fp-ts/(\\w*)$", "replacement": "fp-ts/lib/$1.js" },
+          { "original": "^io-ts/(\\w*)$", "replacement": "io-ts/lib/$1.js" }
+        ]
+      }
+    ]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -14,16 +14,16 @@
     "access": "public"
   },
   "main": "./dist/index.js",
-  "module": "./dist/esm/index.mjs",
+  "module": "./dist/_esm/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/esm/index.mjs",
+      "import": "./dist/_esm/index.mjs",
       "require": "./dist/index.js"
     },
     "./*": {
       "types": "./dist/*.d.ts",
-      "import": "./dist/esm/*.mjs",
+      "import": "./dist/_esm/*.mjs",
       "require": "./dist/*.js"
     }
   },
@@ -85,6 +85,7 @@
     "@typescript-eslint/eslint-plugin": "^4.25.0",
     "@typescript-eslint/parser": "^4.25.0",
     "babel-plugin-annotate-pure-calls": "^0.4.0",
+    "babel-plugin-transform-rename-import": "^2.3.0",
     "colorette": "^2.0.19",
     "concurrently": "^7.2.2",
     "cspell": "^5.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schemata-ts",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A collection of Schemata inspired by io-ts-types and validators.js",
   "homepage": "https://jacob-alford.github.io/schemata-ts/",
   "repository": {
@@ -18,11 +18,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "node": "./dist/index.js",
       "import": "./dist/_esm/index.mjs",
       "require": "./dist/index.js"
     },
     "./*": {
       "types": "./dist/*.d.ts",
+      "node": "./dist/*.js",
       "import": "./dist/_esm/*.mjs",
       "require": "./dist/*.js"
     }

--- a/scripts/pack.ts
+++ b/scripts/pack.ts
@@ -34,10 +34,16 @@ export const copyPackageJson: Build<void> = C =>
         exports: {
           '.': {
             types: './index.d.ts',
+            node: './index.js',
             import: './_esm/index.mjs',
             require: './index.js',
           },
-          './*': { types: './*.d.ts', import: './_esm/*.mjs', require: './*.js' },
+          './*': {
+            types: './*.d.ts',
+            node: './*.js',
+            import: './_esm/*.mjs',
+            require: './*.js',
+          },
         },
         publishConfig: {
           access: 'public',
@@ -78,9 +84,9 @@ export const rewriteSourceMap: (
             ? v.map(source => {
                 let clone = `${source}`
                 if (path_.match(/dist\/_(.+)\//)) {
-                  clone = clone.replace(/(.*)\.\.\/src(.*)/gm, '$1_src$2')
+                  clone = clone.replace(/(.*)\.\.\/src(.*)/gm, '$1src$2')
                 } else {
-                  clone = clone.replace(/(.*)\.\.\/\.\.\/src(.*)/gm, '$1_src$2')
+                  clone = clone.replace(/(.*)\.\.\/\.\.\/src(.*)/gm, '$1src$2')
                 }
                 clone = path.posix.relative(dir, path.posix.join(dir, clone))
                 return clone.startsWith('.') ? clone : './' + clone
@@ -104,8 +110,8 @@ export const copyMetaFiles: Build<ReadonlyArray<void>> = C =>
 
 export const copyBuildFiles: Build<void> = C =>
   pipe(
-    C.mkdir(`./dist/_src`),
-    TE.chain(() => C.exec('cp -r ./src/* ./dist/_src')),
+    C.mkdir(`./dist/src`),
+    TE.chain(() => C.exec('cp -r ./src/* ./dist/src')),
 
     /* Copy build/esm to dist/_esm */
     TE.chain(() => C.mkdir('./dist/_esm')),

--- a/src/schemata/boolean/BooleanFromNumber.ts
+++ b/src/schemata/boolean/BooleanFromNumber.ts
@@ -6,7 +6,7 @@
  *
  * @since 1.0.0
  */
-import { boolean } from 'io-ts/lib/Guard'
+import { boolean } from 'io-ts/Guard'
 import { make, SchemaExt } from 'schemata-ts/SchemaExt'
 
 /**

--- a/src/schemata/boolean/BooleanFromString.ts
+++ b/src/schemata/boolean/BooleanFromString.ts
@@ -4,7 +4,7 @@
  * @since 1.0.0
  */
 import { pipe } from 'fp-ts/function'
-import { boolean } from 'io-ts/lib/Guard'
+import { boolean } from 'io-ts/Guard'
 import * as PB from 'schemata-ts/PatternBuilder'
 import { make, SchemaExt } from 'schemata-ts/SchemaExt'
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,7 +11,7 @@
     "stripInternal": true,
     "module": "ESNext",
     "target": "ESNext",
-    "tsBuildInfoFile": "./dist/tsconfig.build.tsbuildinfo"
+    "tsBuildInfoFile": "./build/tsconfig.build.tsbuildinfo"
   },
   "include": ["./src"],
   "exclude": ["src/__tests__/*.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2231,6 +2231,11 @@ babel-plugin-polyfill-regenerator@^0.4.0:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.3.2"
 
+babel-plugin-transform-rename-import@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-rename-import/-/babel-plugin-transform-rename-import-2.3.0.tgz#5d9d645f937b0ca5c26a24b2510a06277b6ffd9b"
+  integrity sha512-dPgJoT57XC0PqSnLgl2FwNvxFrWlspatX2dkk7yjKQj5HHGw071vAcOf+hqW8ClqcBDMvEbm6mevn5yHAD8mlQ==
+
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"


### PR DESCRIPTION
Fp-ts doesn't work with ESModules (because fp-ts is missing a `type: "module"` in its package.json (or does not use `.mjs` file extensions), but schemata-ts can if all imports from built files reference `fp-ts/lib/*`.  Because schemata-ts has never worked with ESM, this is not a breaking change.