### PR TITLE
[#246] Struct Tools

### DIFF
--- a/src/internal/type-utils.ts
+++ b/src/internal/type-utils.ts
@@ -1,0 +1,5 @@
+export type Combine<A> = {
+  [K in keyof A]: A[K]
+} extends infer B
+  ? B
+  : never

--- a/src/schemables/WithStructM/definition.ts
+++ b/src/schemables/WithStructM/definition.ts
@@ -4,16 +4,9 @@
  * @since 1.3.0
  */
 import { HKT2, Kind, Kind2, URIS, URIS2 } from 'fp-ts/HKT'
-import {
-  KeyFlag,
-  KeyNotMapped,
-  OptionalKeyFlag,
-  Prop,
-  Prop1,
-  Prop2,
-  RequiredKeyFlag,
-} from 'schemata-ts/struct'
-/* eslint-disable @typescript-eslint/ban-types */
+import { Combine } from 'schemata-ts/internal/type-utils'
+import * as _ from 'schemata-ts/schemables/WithStructM/type-utils'
+import { KeyFlag, KeyNotMapped, Prop, Prop1, Prop2 } from 'schemata-ts/struct'
 
 /**
  * Mapped struct configuration determining how to handle extra (non-specified) fields.
@@ -58,89 +51,6 @@ interface StrippedStruct {
   readonly extraProps: 'strip'
 }
 
-// #region Type Helpers
-type Combine<A> = {
-  [K in keyof A]: A[K]
-} extends infer B
-  ? B
-  : never
-
-type OptionalProps<T> = {
-  [K in keyof T]: T[K] extends { readonly _flag: OptionalKeyFlag } ? K : never
-}[keyof T]
-
-type RequiredProps<T> = {
-  [K in keyof T]: T[K] extends { readonly _flag: RequiredKeyFlag } ? K : never
-}[keyof T]
-
-type RemapKey<KeyIn, Prop> = Prop extends { readonly _keyRemap: infer KeyOut }
-  ? KeyOut extends KeyNotMapped
-    ? KeyIn
-    : KeyOut
-  : never
-
-type InnerValue1<S extends URIS, Prop> = Prop extends {
-  readonly _val: infer Val
-}
-  ? Val extends Kind<S, infer A>
-    ? A
-    : never
-  : never
-
-type RestValue1<S extends URIS, RestKind> = RestKind extends undefined
-  ? unknown
-  : { [key: string]: RestKind extends Kind<S, infer A> ? A : never } | {}
-
-type InputHKT2<S, Prop> = Prop extends {
-  readonly _val: infer Val
-}
-  ? Val extends HKT2<S, infer E, any>
-    ? E
-    : never
-  : never
-
-type OutputHKT2<S, Prop> = Prop extends {
-  readonly _val: infer Val
-}
-  ? Val extends HKT2<S, any, infer A>
-    ? A
-    : never
-  : never
-
-type RestInputHKT2<S, RestKind> = RestKind extends undefined
-  ? unknown
-  : { [key: string]: RestKind extends HKT2<S, infer E, any> ? E : never } | {}
-
-type RestOutputHKT2<S, RestKind> = RestKind extends undefined
-  ? unknown
-  : { [key: string]: RestKind extends HKT2<S, any, infer A> ? A : never } | {}
-
-type Input2<S extends URIS2, Prop> = Prop extends {
-  readonly _val: infer Val
-}
-  ? Val extends Kind2<S, infer E, any>
-    ? E
-    : never
-  : never
-
-type Output2<S extends URIS2, Prop> = Prop extends {
-  readonly _val: infer Val
-}
-  ? Val extends Kind2<S, any, infer A>
-    ? A
-    : never
-  : never
-
-type RestInput2<S extends URIS2, RestKind> = RestKind extends undefined
-  ? unknown
-  : { [key: string]: RestKind extends Kind2<S, infer E, any> ? E : never } | {}
-
-type RestOutput2<S extends URIS2, RestKind> = RestKind extends undefined
-  ? unknown
-  : { [key: string]: RestKind extends Kind2<S, any, infer A> ? A : never } | {}
-
-// #endregion
-
 /**
  * @since 1.3.0
  * @category Model
@@ -158,17 +68,23 @@ export interface WithStructMHKT2<S> {
   ) => HKT2<
     S,
     Combine<
-      RestInputHKT2<S, RestKind> & {
-        [K in RequiredProps<Props>]: InputHKT2<S, Props[K]>
+      _.RestInputHKT2<S, RestKind> & {
+        [K in _.RequiredProps<Props>]: _.InputHKT2<S, Props[K]>
       } & {
-        [K in OptionalProps<Props>]?: InputHKT2<S, Props>
+        [K in _.OptionalProps<Props>]?: _.InputHKT2<S, Props>
       }
     >,
     Combine<
-      RestOutputHKT2<S, RestKind> & {
-        [K in RequiredProps<Props> as RemapKey<K, Props[K]>]: OutputHKT2<S, Props[K]>
+      _.RestOutputHKT2<S, RestKind> & {
+        [K in _.RequiredProps<Props> as _.RemapKey<K, Props[K]>]: _.OutputHKT2<
+          S,
+          Props[K]
+        >
       } & {
-        [K in OptionalProps<Props> as RemapKey<K, Props[K]>]?: OutputHKT2<S, Props[K]>
+        [K in _.OptionalProps<Props> as _.RemapKey<K, Props[K]>]?: _.OutputHKT2<
+          S,
+          Props[K]
+        >
       }
     >
   >
@@ -188,10 +104,16 @@ export interface WithStructM1<S extends URIS> {
   ) => Kind<
     S,
     Combine<
-      RestValue1<S, RestKind> & {
-        [K in RequiredProps<Props> as RemapKey<K, Props[K]>]: InnerValue1<S, Props[K]>
+      _.RestValue1<S, RestKind> & {
+        [K in _.RequiredProps<Props> as _.RemapKey<K, Props[K]>]: _.InnerValue1<
+          S,
+          Props[K]
+        >
       } & {
-        [K in OptionalProps<Props> as RemapKey<K, Props[K]>]?: InnerValue1<S, Props[K]>
+        [K in _.OptionalProps<Props> as _.RemapKey<K, Props[K]>]?: _.InnerValue1<
+          S,
+          Props[K]
+        >
       }
     >
   >
@@ -214,17 +136,17 @@ export interface WithStructM2<S extends URIS2> {
   ) => Kind2<
     S,
     Combine<
-      RestInput2<S, RestKind> & {
-        [K in RequiredProps<Props>]: Input2<S, Props[K]>
+      _.RestInput2<S, RestKind> & {
+        [K in _.RequiredProps<Props>]: _.Input2<S, Props[K]>
       } & {
-        [K in OptionalProps<Props>]?: Input2<S, Props[K]>
+        [K in _.OptionalProps<Props>]?: _.Input2<S, Props[K]>
       }
     >,
     Combine<
-      RestOutput2<S, RestKind> & {
-        [K in RequiredProps<Props> as RemapKey<K, Props[K]>]: Output2<S, Props[K]>
+      _.RestOutput2<S, RestKind> & {
+        [K in _.RequiredProps<Props> as _.RemapKey<K, Props[K]>]: _.Output2<S, Props[K]>
       } & {
-        [K in OptionalProps<Props> as RemapKey<K, Props[K]>]?: Output2<S, Props[K]>
+        [K in _.OptionalProps<Props> as _.RemapKey<K, Props[K]>]?: _.Output2<S, Props[K]>
       }
     >
   >
@@ -248,10 +170,10 @@ export interface WithStructM2C<S extends URIS2, E> {
     S,
     E,
     Combine<
-      RestOutput2<S, RestKind> & {
-        [K in RequiredProps<Props> as RemapKey<K, Props[K]>]: Output2<S, Props[K]>
+      _.RestOutput2<S, RestKind> & {
+        [K in _.RequiredProps<Props> as _.RemapKey<K, Props[K]>]: _.Output2<S, Props[K]>
       } & {
-        [K in OptionalProps<Props> as RemapKey<K, Props[K]>]?: Output2<S, Props[K]>
+        [K in _.OptionalProps<Props> as _.RemapKey<K, Props[K]>]?: _.Output2<S, Props[K]>
       }
     >
   >

--- a/src/schemables/WithStructM/definition.ts
+++ b/src/schemables/WithStructM/definition.ts
@@ -4,258 +4,16 @@
  * @since 1.3.0
  */
 import { HKT2, Kind, Kind2, URIS, URIS2 } from 'fp-ts/HKT'
+import {
+  KeyFlag,
+  KeyNotMapped,
+  OptionalKeyFlag,
+  Prop,
+  Prop1,
+  Prop2,
+  RequiredKeyFlag,
+} from 'schemata-ts/struct'
 /* eslint-disable @typescript-eslint/ban-types */
-
-/**
- * @since 1.3.0
- * @category Model
- */
-export type OptionalKeyFlag = typeof OptionalKeyFlag
-const OptionalKeyFlag = Symbol()
-
-/**
- * @since 1.3.0
- * @category Model
- */
-type RequiredKeyFlag = typeof RequiredKeyFlag
-const RequiredKeyFlag = Symbol()
-
-/**
- * @since 1.3.0
- * @category Model
- */
-export type KeyNotMapped = typeof KeyNotMapped
-const KeyNotMapped = Symbol()
-
-/**
- * @since 1.3.0
- * @category Model
- */
-export type KeyFlag = OptionalKeyFlag | RequiredKeyFlag
-
-/**
- * Meta information for an HKT2 for if the key is optional or required, and if the key is remapped
- *
- * @since 1.3.0
- * @category Model
- */
-export interface Prop<
-  Flag extends KeyFlag,
-  S,
-  Val extends HKT2<S, any, any>,
-  K extends string | KeyNotMapped,
-> {
-  readonly _flag: Flag
-  readonly _keyRemap: K
-  readonly _val: Val
-}
-
-/**
- * Meta information for a Kind for if the key is optional or required, and if the key is remapped
- *
- * @since 1.3.0
- * @category Model
- */
-export interface Prop1<
-  Flag extends KeyFlag,
-  S extends URIS,
-  Val extends Kind<S, any>,
-  K extends string | KeyNotMapped,
-> {
-  readonly _flag: Flag
-  readonly _keyRemap: K
-  readonly _val: Val
-}
-
-/**
- * Meta information for a Kind2 for if the key is optional or required, and if the key is remapped
- *
- * @since 1.3.0
- * @category Model
- */
-export interface Prop2<
-  Flag extends KeyFlag,
-  S extends URIS2,
-  Val extends Kind2<S, any, any>,
-  K extends string | KeyNotMapped,
-> {
-  readonly _flag: Flag
-  readonly _keyRemap: K
-  readonly _val: Val
-}
-
-type Required = {
-  /**
-   * Used to indicate that a property is required
-   *
-   * @since 1.3.0
-   */
-  <S extends URIS2, Val extends Kind2<S, any, any>>(val: Val): Prop2<
-    RequiredKeyFlag,
-    S,
-    Val,
-    KeyNotMapped
-  >
-  /**
-   * Used to indicate that a property is required
-   *
-   * @since 1.3.0
-   */
-  <S extends URIS, Val extends Kind<S, any>>(val: Val): Prop1<
-    RequiredKeyFlag,
-    S,
-    Val,
-    KeyNotMapped
-  >
-  /**
-   * Used to indicate that a property is required
-   *
-   * @since 1.3.0
-   */
-  <S, Val extends HKT2<S, any, any>>(val: Val): Prop<
-    RequiredKeyFlag,
-    S,
-    Val,
-    KeyNotMapped
-  >
-}
-
-/** @internal */
-const required: Required = (val: any) =>
-  ({
-    _flag: RequiredKeyFlag,
-    _keyRemap: KeyNotMapped,
-    _val: val,
-  } as any)
-
-/**
- * @since 1.3.0
- * @category Guards
- */
-export const isRequiredFlag = (flag: KeyFlag): flag is RequiredKeyFlag =>
-  flag === RequiredKeyFlag
-
-type Optional = {
-  /**
-   * Used to indicate that a property is optional
-   *
-   * @since 1.3.0
-   */
-  <S extends URIS2, Val extends Kind2<S, any, any>>(val: Val): Prop2<
-    OptionalKeyFlag,
-    S,
-    Val,
-    KeyNotMapped
-  >
-  /**
-   * Used to indicate that a property is optional
-   *
-   * @since 1.3.0
-   */
-  <S extends URIS, Val extends Kind<S, any>>(val: Val): Prop1<
-    OptionalKeyFlag,
-    S,
-    Val,
-    KeyNotMapped
-  >
-  /**
-   * Used to indicate that a property is optional
-   *
-   * @since 1.3.0
-   */
-  <S, Val extends HKT2<S, any, any>>(val: Val): Prop<
-    OptionalKeyFlag,
-    S,
-    Val,
-    KeyNotMapped
-  >
-}
-
-/** @internal */
-const optional: Optional = (val: any) =>
-  ({
-    _flag: OptionalKeyFlag,
-    _keyRemap: KeyNotMapped,
-    _val: val,
-  } as any)
-
-type MapKeyTo = {
-  /**
-   * Used to remap a property's key to a new key in the output type
-   *
-   * @since 1.3.0
-   */
-  <K extends string>(mapTo: K): <
-    Flag extends KeyFlag,
-    S extends URIS2,
-    Val extends Kind2<S, any, any>,
-  >(
-    prop: Prop2<Flag, S, Val, KeyNotMapped>,
-  ) => Prop2<Flag, S, Val, K>
-  /**
-   * Used to remap a property's key to a new key in the output type
-   *
-   * @since 1.3.0
-   */
-  <K extends string>(mapTo: K): <
-    Flag extends KeyFlag,
-    S extends URIS,
-    Val extends Kind<S, any>,
-  >(
-    prop: Prop1<Flag, S, Val, KeyNotMapped>,
-  ) => Prop1<Flag, S, Val, K>
-  /**
-   * Used to remap a property's key to a new key in the output type
-   *
-   * @since 1.3.0
-   */
-  <K extends string>(mapTo: K): <Flag extends KeyFlag, S, Val extends HKT2<S, any, any>>(
-    prop: Prop<Flag, S, Val, KeyNotMapped>,
-  ) => Prop<Flag, S, Val, K>
-}
-
-/**
- * @since 1.3.0
- * @category Guards
- */
-export const isOptionalFlag = (flag: KeyFlag): flag is OptionalKeyFlag =>
-  flag === OptionalKeyFlag
-
-/** @internal */
-const mapKeyTo: MapKeyTo = mapTo => (prop: any) => ({
-  ...prop,
-  _keyRemap: mapTo,
-})
-
-/**
- * @since 1.3.0
- * @category Guards
- */
-export const keyIsNotMapped = (key: string | KeyNotMapped): key is KeyNotMapped =>
-  key === KeyNotMapped
-
-type Combine<A> = {
-  [K in keyof A]: A[K]
-} extends infer B
-  ? B
-  : never
-
-/**
- * @since 1.3.0
- * @category Model
- */
-export interface StructTools {
-  readonly required: Required
-  readonly optional: Optional
-  readonly mapKeyTo: MapKeyTo
-}
-
-/** @internal */
-export const structTools: StructTools = {
-  required,
-  optional,
-  mapKeyTo,
-}
 
 /**
  * Mapped struct configuration determining how to handle extra (non-specified) fields.
@@ -301,6 +59,12 @@ interface StrippedStruct {
 }
 
 // #region Type Helpers
+type Combine<A> = {
+  [K in keyof A]: A[K]
+} extends infer B
+  ? B
+  : never
+
 type OptionalProps<T> = {
   [K in keyof T]: T[K] extends { readonly _flag: OptionalKeyFlag } ? K : never
 }[keyof T]
@@ -389,7 +153,7 @@ export interface WithStructMHKT2<S> {
     >,
     RestKind extends HKT2<S, any, any> | undefined,
   >(
-    properties: (_: StructTools) => Props,
+    properties: Props,
     params?: StructOptions<RestKind>,
   ) => HKT2<
     S,
@@ -419,7 +183,7 @@ export interface WithStructM1<S extends URIS> {
     Props extends Record<string, Prop1<KeyFlag, S, Kind<S, any>, string | KeyNotMapped>>,
     RestKind extends Kind<S, any> | undefined,
   >(
-    properties: (_: StructTools) => Props,
+    properties: Props,
     params?: StructOptions<RestKind>,
   ) => Kind<
     S,
@@ -445,7 +209,7 @@ export interface WithStructM2<S extends URIS2> {
     >,
     RestKind extends Kind2<S, any, any> | undefined,
   >(
-    properties: (_: StructTools) => Props,
+    properties: Props,
     params?: StructOptions<RestKind>,
   ) => Kind2<
     S,
@@ -478,7 +242,7 @@ export interface WithStructM2C<S extends URIS2, E> {
     >,
     RestKind extends Kind2<S, any, any> | undefined,
   >(
-    properties: (_: StructTools) => Props,
+    properties: Props,
     params?: StructOptions<RestKind>,
   ) => Kind2<
     S,

--- a/src/schemables/WithStructM/instances/arbitrary.ts
+++ b/src/schemables/WithStructM/instances/arbitrary.ts
@@ -6,21 +6,15 @@
 import { pipe, tuple } from 'fp-ts/function'
 import * as Arb from 'schemata-ts/base/ArbitraryBase'
 import { forIn, hasOwn } from 'schemata-ts/internal/util'
-import {
-  isOptionalFlag,
-  KeyFlag,
-  keyIsNotMapped,
-  structTools,
-  WithStructM1,
-} from 'schemata-ts/schemables/WithStructM/definition'
+import { WithStructM1 } from 'schemata-ts/schemables/WithStructM/definition'
+import { isOptionalFlag, KeyFlag, keyIsNotMapped } from 'schemata-ts/struct'
 
 /**
  * @since 1.3.0
  * @category Instances
  */
 export const Arbitrary: WithStructM1<Arb.URI> = {
-  structM: (getProperties, params = { extraProps: 'strip' }) => {
-    const properties = getProperties(structTools)
+  structM: (properties, params = { extraProps: 'strip' }) => {
     const remappedProps: Record<string, readonly [KeyFlag, Arb.Arbitrary<unknown>]> = {}
     for (const key in properties) {
       const prop = properties[key]

--- a/src/schemables/WithStructM/instances/decoder.ts
+++ b/src/schemables/WithStructM/instances/decoder.ts
@@ -11,13 +11,8 @@ import * as DE from 'io-ts/DecodeError'
 import * as D from 'io-ts/Decoder'
 import * as FS from 'io-ts/FreeSemigroup'
 import { hasOwn, witherSM } from 'schemata-ts/internal/util'
-import {
-  isOptionalFlag,
-  isRequiredFlag,
-  keyIsNotMapped,
-  structTools,
-  WithStructM2C,
-} from 'schemata-ts/schemables/WithStructM/definition'
+import { WithStructM2C } from 'schemata-ts/schemables/WithStructM/definition'
+import { isOptionalFlag, isRequiredFlag, keyIsNotMapped } from 'schemata-ts/struct'
 
 const decodeErrorValidation = E.getApplicativeValidation(DE.getSemigroup<string>())
 const apSecond = Ap.apSecond(decodeErrorValidation)
@@ -27,8 +22,7 @@ const apSecond = Ap.apSecond(decodeErrorValidation)
  * @category Instances
  */
 export const Decoder: WithStructM2C<D.URI, unknown> = {
-  structM: (getProperties, params = { extraProps: 'strip' }) => {
-    const properties = getProperties(structTools)
+  structM: (properties, params = { extraProps: 'strip' }) => {
     return {
       decode: flow(
         D.UnknownRecord.decode,

--- a/src/schemables/WithStructM/instances/encoder.ts
+++ b/src/schemables/WithStructM/instances/encoder.ts
@@ -6,19 +6,15 @@
 import { tuple } from 'fp-ts/function'
 import * as Enc from 'io-ts/Encoder'
 import { hasOwn } from 'schemata-ts/internal/util'
-import {
-  keyIsNotMapped,
-  structTools,
-  WithStructM2,
-} from 'schemata-ts/schemables/WithStructM/definition'
+import { WithStructM2 } from 'schemata-ts/schemables/WithStructM/definition'
+import { keyIsNotMapped } from 'schemata-ts/struct'
 
 /**
  * @since 1.3.0
  * @category Instances
  */
 export const Encoder: WithStructM2<Enc.URI> = {
-  structM: (getProperties, params = { extraProps: 'strip' }) => {
-    const properties = getProperties(structTools)
+  structM: (properties, params = { extraProps: 'strip' }) => {
     const keyLookup: Record<
       // -- expected key of the output object
       string,

--- a/src/schemables/WithStructM/instances/eq.ts
+++ b/src/schemables/WithStructM/instances/eq.ts
@@ -9,15 +9,14 @@ import * as RR from 'fp-ts/ReadonlyRecord'
 import * as Str from 'fp-ts/string'
 import * as Eq_ from 'schemata-ts/base/EqBase'
 import { hasOwn } from 'schemata-ts/internal/util'
-import { structTools, WithStructM1 } from 'schemata-ts/schemables/WithStructM/definition'
+import { WithStructM1 } from 'schemata-ts/schemables/WithStructM/definition'
 
 /**
  * @since 1.3.0
  * @category Instances
  */
 export const Eq: WithStructM1<Eq_.URI> = {
-  structM: (getProperties, params = { extraProps: 'strip' }) => {
-    const properties = getProperties(structTools)
+  structM: (properties, params = { extraProps: 'strip' }) => {
     const eqs: Record<string, Eq_.Eq<unknown>> = pipe(
       properties,
       RR.map(({ _val }) => _val),

--- a/src/schemables/WithStructM/instances/guard.ts
+++ b/src/schemables/WithStructM/instances/guard.ts
@@ -10,21 +10,15 @@ import * as RR from 'fp-ts/ReadonlyRecord'
 import * as Str from 'fp-ts/string'
 import * as G from 'io-ts/Guard'
 import { hasOwn } from 'schemata-ts/internal/util'
-import {
-  isOptionalFlag,
-  KeyFlag,
-  keyIsNotMapped,
-  structTools,
-  WithStructM1,
-} from 'schemata-ts/schemables/WithStructM/definition'
+import { WithStructM1 } from 'schemata-ts/schemables/WithStructM/definition'
+import { isOptionalFlag, KeyFlag, keyIsNotMapped } from 'schemata-ts/struct'
 
 /**
  * @since 1.3.0
  * @category Instances
  */
 export const Guard: WithStructM1<G.URI> = {
-  structM: (getProps, params = { extraProps: 'strip' }) => {
-    const properties = getProps(structTools)
+  structM: (properties, params = { extraProps: 'strip' }) => {
     const remappedProps: Record<string, readonly [KeyFlag, G.Guard<unknown, unknown>]> =
       {}
     for (const key in properties) {

--- a/src/schemables/WithStructM/instances/json-schema.ts
+++ b/src/schemables/WithStructM/instances/json-schema.ts
@@ -11,19 +11,15 @@ import * as RR from 'fp-ts/ReadonlyRecord'
 import * as Sg from 'fp-ts/Semigroup'
 import * as Str from 'fp-ts/string'
 import * as JS from 'schemata-ts/base/JsonSchemaBase'
-import {
-  isRequiredFlag,
-  structTools,
-  WithStructM2,
-} from 'schemata-ts/schemables/WithStructM/definition'
+import { WithStructM2 } from 'schemata-ts/schemables/WithStructM/definition'
+import { isRequiredFlag } from 'schemata-ts/struct'
 
 /**
  * @since 1.2.0
  * @category Instances
  */
 export const JsonSchema: WithStructM2<JS.URI> = {
-  structM: (getProps, params = { extraProps: 'strip' }) => {
-    const properties = getProps(structTools)
+  structM: (properties, params = { extraProps: 'strip' }) => {
     const [requiredKeys, jsonSchema] = pipe(
       properties,
       RR.foldMapWithIndex(Str.Ord)(

--- a/src/schemables/WithStructM/instances/json-schema.ts
+++ b/src/schemables/WithStructM/instances/json-schema.ts
@@ -1,7 +1,7 @@
 /**
- * Represents a ReadonlyMap converted from an expected array of entries.
+ * WithStructM instance for JsonSchema
  *
- * @since 1.2.0
+ * @since 1.3.0
  */
 import { Const, make } from 'fp-ts/Const'
 import { pipe, tuple } from 'fp-ts/function'
@@ -15,7 +15,7 @@ import { WithStructM2 } from 'schemata-ts/schemables/WithStructM/definition'
 import { isRequiredFlag } from 'schemata-ts/struct'
 
 /**
- * @since 1.2.0
+ * @since 1.3.0
  * @category Instances
  */
 export const JsonSchema: WithStructM2<JS.URI> = {

--- a/src/schemables/WithStructM/instances/printer.ts
+++ b/src/schemables/WithStructM/instances/printer.ts
@@ -9,19 +9,15 @@ import * as O from 'fp-ts/Option'
 import * as P from 'schemata-ts/base/PrinterBase'
 import { hasOwn, witherS } from 'schemata-ts/internal/util'
 import * as PE from 'schemata-ts/PrintError'
-import {
-  keyIsNotMapped,
-  structTools,
-  WithStructM2,
-} from 'schemata-ts/schemables/WithStructM/definition'
+import { WithStructM2 } from 'schemata-ts/schemables/WithStructM/definition'
+import { keyIsNotMapped } from 'schemata-ts/struct'
 
 /**
  * @since 1.1.0
  * @category Instances
  */
 export const Printer: WithStructM2<P.URI> = {
-  structM: (getProps, params = { extraProps: 'strip' }) => {
-    const properties = getProps(structTools)
+  structM: (properties, params = { extraProps: 'strip' }) => {
     const printersByKey: Record<string, P.Printer<unknown, unknown>['codomainToJson']> =
       {}
     const printersByMappedKey: Record<

--- a/src/schemables/WithStructM/instances/printer.ts
+++ b/src/schemables/WithStructM/instances/printer.ts
@@ -1,7 +1,7 @@
 /**
- * Represents a ReadonlyMap converted from an expected array of entries.
+ * WithStructM instance for Printer
  *
- * @since 1.1.0
+ * @since 1.3.0
  */
 import * as E from 'fp-ts/Either'
 import { pipe } from 'fp-ts/function'
@@ -13,7 +13,7 @@ import { WithStructM2 } from 'schemata-ts/schemables/WithStructM/definition'
 import { keyIsNotMapped } from 'schemata-ts/struct'
 
 /**
- * @since 1.1.0
+ * @since 1.3.0
  * @category Instances
  */
 export const Printer: WithStructM2<P.URI> = {

--- a/src/schemables/WithStructM/instances/schema.ts
+++ b/src/schemables/WithStructM/instances/schema.ts
@@ -1,7 +1,7 @@
 /**
- * Represents a ReadonlyMap converted from an expected array of entries.
+ * WithStructM instance for Schema
  *
- * @since 1.0.0
+ * @since 1.3.0
  */
 import { pipe } from 'fp-ts/function'
 import * as RR from 'fp-ts/ReadonlyRecord'
@@ -9,7 +9,7 @@ import { URI } from 'schemata-ts/base/SchemaBase'
 import { WithStructM2 } from 'schemata-ts/schemables/WithStructM/definition'
 
 /**
- * @since 1.0.0
+ * @since 1.3.0
  * @category Instances
  */
 export const Schema: WithStructM2<URI>['structM'] =

--- a/src/schemables/WithStructM/instances/schema.ts
+++ b/src/schemables/WithStructM/instances/schema.ts
@@ -3,51 +3,27 @@
  *
  * @since 1.0.0
  */
-import { identity, pipe } from 'fp-ts/function'
-import { Kind2 } from 'fp-ts/HKT'
+import { pipe } from 'fp-ts/function'
 import * as RR from 'fp-ts/ReadonlyRecord'
 import { URI } from 'schemata-ts/base/SchemaBase'
-import {
-  KeyFlag,
-  KeyNotMapped,
-  Prop2,
-  StructTools,
-  structTools,
-  WithStructM2,
-} from 'schemata-ts/schemables/WithStructM/definition'
-
-/**
- * A tool for reusing struct definitions across multiple struct combinators
- *
- * @since 1.3.0
- * @category Constructors
- */
-export const defineStruct: <
-  Props extends Record<
-    string,
-    Prop2<KeyFlag, URI, Kind2<URI, unknown, unknown>, string | KeyNotMapped>
-  >,
->(
-  makeProps: (_: StructTools) => Props,
-) => (_: StructTools) => Props = identity
+import { WithStructM2 } from 'schemata-ts/schemables/WithStructM/definition'
 
 /**
  * @since 1.0.0
  * @category Instances
  */
 export const Schema: WithStructM2<URI>['structM'] =
-  (makeProps, params = { extraProps: 'strip' }) =>
+  (properties, params = { extraProps: 'strip' }) =>
   S => {
-    const properties = makeProps(structTools)
     const schemafiedProps = pipe(
       properties,
       RR.map(({ _val, ...rest }) => ({ _val: _val(S), ...rest })),
     )
     if (params.extraProps === 'restParam' && params.restParam !== undefined) {
-      return S.structM(() => schemafiedProps, {
+      return S.structM(schemafiedProps, {
         extraProps: 'restParam',
         restParam: params.restParam(S),
       })
     }
-    return S.structM(() => schemafiedProps, params as any) as any
+    return S.structM(schemafiedProps, params as any) as any
   }

--- a/src/schemables/WithStructM/instances/task-decoder.ts
+++ b/src/schemables/WithStructM/instances/task-decoder.ts
@@ -1,7 +1,7 @@
 /**
- * Represents a ReadonlyMap converted from an expected array of entries.
+ * WithStructM instance for TaskDecoder
  *
- * @since 1.0.0
+ * @since 1.3.0
  */
 import * as Ap from 'fp-ts/Apply'
 import { flow, pipe } from 'fp-ts/function'
@@ -22,7 +22,7 @@ const decodeErrorValidation = TE.getApplicativeTaskValidation(
 const apSecond = Ap.apSecond(decodeErrorValidation)
 
 /**
- * @since 1.0.0
+ * @since 1.3.0
  * @category Instances
  */
 export const TaskDecoder: WithStructM2C<TD.URI, unknown> = {

--- a/src/schemables/WithStructM/instances/task-decoder.ts
+++ b/src/schemables/WithStructM/instances/task-decoder.ts
@@ -12,13 +12,8 @@ import * as DE from 'io-ts/DecodeError'
 import * as FS from 'io-ts/FreeSemigroup'
 import * as TD from 'io-ts/TaskDecoder'
 import { hasOwn, witherTaskParSM } from 'schemata-ts/internal/util'
-import {
-  isOptionalFlag,
-  isRequiredFlag,
-  keyIsNotMapped,
-  structTools,
-  WithStructM2C,
-} from 'schemata-ts/schemables/WithStructM/definition'
+import { WithStructM2C } from 'schemata-ts/schemables/WithStructM/definition'
+import { isOptionalFlag, isRequiredFlag, keyIsNotMapped } from 'schemata-ts/struct'
 
 const decodeErrorValidation = TE.getApplicativeTaskValidation(
   T.ApplicativePar,
@@ -31,109 +26,105 @@ const apSecond = Ap.apSecond(decodeErrorValidation)
  * @category Instances
  */
 export const TaskDecoder: WithStructM2C<TD.URI, unknown> = {
-  structM: (getProperties, params = { extraProps: 'strip' }) => {
-    const properties = getProperties(structTools)
-    return {
-      decode: flow(
-        TD.UnknownRecord.decode,
-        TE.chain(u => {
-          const config = params
-          const outKnown = pipe(
-            properties,
-            witherTaskParSM(DE.getSemigroup<string>())(
-              (key, { _flag, _keyRemap, _val }) => {
-                const val: unknown = (u as any)[key]
-                // -- If the input _does not_ have a specified property key _and_ that key is required: return a key failure
-                if (!hasOwn(u, key) && isRequiredFlag(_flag)) {
-                  return TE.left(
+  structM: (properties, params = { extraProps: 'strip' }) => ({
+    decode: flow(
+      TD.UnknownRecord.decode,
+      TE.chain(u => {
+        const config = params
+        const outKnown = pipe(
+          properties,
+          witherTaskParSM(DE.getSemigroup<string>())(
+            (key, { _flag, _keyRemap, _val }) => {
+              const val: unknown = (u as any)[key]
+              // -- If the input _does not_ have a specified property key _and_ that key is required: return a key failure
+              if (!hasOwn(u, key) && isRequiredFlag(_flag)) {
+                return TE.left(
+                  FS.of(
+                    DE.key(
+                      key as string,
+                      DE.required,
+                      FS.of(DE.leaf(val, 'Missing Required Property')),
+                    ),
+                  ),
+                )
+              }
+
+              // -- If the input _does not_ have a specified property key _and_ that key is optional: filter that property out
+              if ((!hasOwn(u, key) || val === undefined) && isOptionalFlag(_flag)) {
+                return TE.right(O.none)
+              }
+
+              // -- If the input _does_ have a specified property key: validate it
+              return pipe(
+                _val.decode(val),
+                TE.bimap(
+                  error =>
                     FS.of(
                       DE.key(
                         key as string,
-                        DE.required,
-                        FS.of(DE.leaf(val, 'Missing Required Property')),
+                        isOptionalFlag(_flag) ? DE.optional : DE.required,
+                        error,
                       ),
                     ),
-                  )
-                }
+                  result => O.some([result, keyIsNotMapped(_keyRemap) ? key : _keyRemap]),
+                ),
+              )
+            },
+          ),
+        )
 
-                // -- If the input _does not_ have a specified property key _and_ that key is optional: filter that property out
-                if ((!hasOwn(u, key) || val === undefined) && isOptionalFlag(_flag)) {
-                  return TE.right(O.none)
-                }
+        // -- If parameters are set to strip additional properties, return just the decoded known properties
+        if (config.extraProps === 'strip') return outKnown
 
-                // -- If the input _does_ have a specified property key: validate it
-                return pipe(
-                  _val.decode(val),
-                  TE.bimap(
-                    error =>
-                      FS.of(
-                        DE.key(
-                          key as string,
-                          isOptionalFlag(_flag) ? DE.optional : DE.required,
-                          error,
-                        ),
-                      ),
-                    result =>
-                      O.some([result, keyIsNotMapped(_keyRemap) ? key : _keyRemap]),
-                  ),
-                )
-              },
-            ),
-          )
-
-          // -- If parameters are set to strip additional properties, return just the decoded known properties
-          if (config.extraProps === 'strip') return outKnown
-
-          // -- if extra props are not allowed, return a failure on keys not specified in properties
-          if (config.extraProps === 'error') {
-            return pipe(
-              u,
-              witherTaskParSM(DE.getSemigroup<string>())(key => {
-                if (!hasOwn(properties, key)) {
-                  return TE.left(FS.of(DE.leaf(key, `Unexpected Property Key`)))
-                }
-                return TE.right(O.none)
-              }),
-              TE.mapLeft(errs =>
-                FS.of(DE.wrap('Encountered Unexpected Property Keys: ', errs)),
-              ),
-              apSecond(outKnown),
-            )
-          }
-
-          const rest = config.restParam
-          if (rest === undefined) return outKnown
-
+        // -- if extra props are not allowed, return a failure on keys not specified in properties
+        if (config.extraProps === 'error') {
           return pipe(
-            outKnown,
-            TE.chain(knownResult =>
-              pipe(
-                u,
-                witherTaskParSM(DE.getSemigroup<string>())((inputKey, inputValue) => {
-                  // -- If the input key is not a known property key (i.e. it was not specified in the struct) decode it with the rest parameter
-                  if (!hasOwn(properties, inputKey) || properties[inputKey] === undefined)
-                    return pipe(
-                      rest.decode(inputValue),
-                      TE.bimap(
-                        err => FS.of(DE.key(inputKey as string, DE.optional, err)),
-                        result => O.some([result, inputKey]),
-                      ),
-                    )
-
-                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                  const { _keyRemap } = properties[inputKey]!
-
-                  // -- If the input key is a known property key (i.e. it was specified in the struct) keep its more precise value
-                  return keyIsNotMapped(_keyRemap)
-                    ? TE.right(O.some([knownResult[inputKey], inputKey]))
-                    : TE.right(O.some([knownResult[_keyRemap], _keyRemap]))
-                }),
-              ),
+            u,
+            witherTaskParSM(DE.getSemigroup<string>())(key => {
+              if (!hasOwn(properties, key)) {
+                return TE.left(FS.of(DE.leaf(key, `Unexpected Property Key`)))
+              }
+              return TE.right(O.none)
+            }),
+            TE.mapLeft(errs =>
+              FS.of(DE.wrap('Encountered Unexpected Property Keys: ', errs)),
             ),
+            apSecond(outKnown),
           )
-        }),
-        a => a as any,
-      ),
-    }
-  },
+        }
+
+        const rest = config.restParam
+        if (rest === undefined) return outKnown
+
+        return pipe(
+          outKnown,
+          TE.chain(knownResult =>
+            pipe(
+              u,
+              witherTaskParSM(DE.getSemigroup<string>())((inputKey, inputValue) => {
+                // -- If the input key is not a known property key (i.e. it was not specified in the struct) decode it with the rest parameter
+                if (!hasOwn(properties, inputKey) || properties[inputKey] === undefined)
+                  return pipe(
+                    rest.decode(inputValue),
+                    TE.bimap(
+                      err => FS.of(DE.key(inputKey as string, DE.optional, err)),
+                      result => O.some([result, inputKey]),
+                    ),
+                  )
+
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                const { _keyRemap } = properties[inputKey]!
+
+                // -- If the input key is a known property key (i.e. it was specified in the struct) keep its more precise value
+                return keyIsNotMapped(_keyRemap)
+                  ? TE.right(O.some([knownResult[inputKey], inputKey]))
+                  : TE.right(O.some([knownResult[_keyRemap], _keyRemap]))
+              }),
+            ),
+          ),
+        )
+      }),
+      a => a as any,
+    ),
+  }),
 }

--- a/src/schemables/WithStructM/instances/type.ts
+++ b/src/schemables/WithStructM/instances/type.ts
@@ -1,27 +1,139 @@
 /**
- * Represents a ReadonlyMap converted from an expected array of entries.
+ * WithStructM instance for Type
  *
- * @since 1.0.0
+ * @deprecated
+ * @since 1.3.0
  */
+import * as Ap from 'fp-ts/Apply'
+import * as A from 'fp-ts/Array'
 import * as E from 'fp-ts/Either'
-import { Type as Type_ } from 'io-ts'
+import { flow, pipe } from 'fp-ts/function'
+import * as O from 'fp-ts/Option'
+import { failure, Type as Type_, unknown, ValidationError } from 'io-ts'
 import * as t from 'io-ts/Type'
+import { hasOwn, witherSM } from 'schemata-ts/internal/util'
 import { WithStructM1 } from 'schemata-ts/schemables/WithStructM/definition'
 import { Encoder } from 'schemata-ts/schemables/WithStructM/instances/encoder'
 import { Guard } from 'schemata-ts/schemables/WithStructM/instances/guard'
+import { isOptionalFlag, isRequiredFlag, keyIsNotMapped } from 'schemata-ts/struct'
+
+const decodeErrorValidation = E.getApplicativeValidation(
+  A.getSemigroup<ValidationError>(),
+)
+const apSecond = Ap.apSecond(decodeErrorValidation)
 
 /**
  * @deprecated
- * @since 1.0.0
+ * @since 1.3.0
  * @category Instances
  */
 export const Type: WithStructM1<t.URI> = {
-  structM: (makeProperties, params) =>
+  structM: (properties, params = { extraProps: 'strip' }) =>
     new Type_(
       `mappedStruct`,
-      Guard.structM(makeProperties, params).is,
-      i =>
-        E.left([{ value: i, context: [], message: 'Type not implemented for StructM' }]),
-      Encoder.structM(makeProperties, params).encode,
+      Guard.structM(properties, params).is as any,
+      flow(
+        t.UnknownRecord.decode,
+        E.chain(u => {
+          const config = params
+          const outKnown = pipe(
+            properties,
+            witherSM(A.getSemigroup<ValidationError>())(
+              (key, { _flag, _keyRemap, _val }): any => {
+                const val: unknown = (u as any)[key]
+                // -- If the input _does not_ have a specified property key _and_ that key is required: return a key failure
+                if (!hasOwn(u, key) && isRequiredFlag(_flag)) {
+                  return failure(
+                    val,
+                    [{ key: key as string, type: unknown }],
+                    'Missing Required Property',
+                  )
+                }
+
+                // -- If the input _does not_ have a specified property key _and_ that key is optional: filter that property out
+                if ((!hasOwn(u, key) || val === undefined) && isOptionalFlag(_flag)) {
+                  return E.right(O.none)
+                }
+
+                // -- If the input _does_ have a specified property key: validate it
+                return pipe(
+                  _val.decode(val),
+                  E.bimap(
+                    A.concat<ValidationError>([
+                      {
+                        value: val,
+                        context: [{ key: key as string, type: _val }],
+                        message: 'Failed to decode property',
+                      },
+                    ]),
+                    result =>
+                      O.some([result, keyIsNotMapped(_keyRemap) ? key : _keyRemap]),
+                  ),
+                )
+              },
+            ),
+          )
+
+          // -- If parameters are set to strip additional properties, return just the decoded known properties
+          if (config.extraProps === 'strip') return outKnown
+
+          // -- if extra props are not allowed, return a failure on keys not specified in properties
+          if (config.extraProps === 'error') {
+            return pipe(
+              u,
+              witherSM(A.getSemigroup<ValidationError>())((key, val) => {
+                if (!hasOwn(properties, key)) {
+                  return failure(
+                    val,
+                    [{ key: key as string, type: unknown }],
+                    'Encountered additional property',
+                  )
+                }
+                return E.right(O.none) as any
+              }),
+              apSecond(outKnown),
+            )
+          }
+
+          const rest = config.restParam
+          if (rest === undefined) return outKnown
+
+          return pipe(
+            outKnown,
+            E.chain(knownResult =>
+              pipe(
+                u,
+                witherSM(A.getSemigroup<ValidationError>())((inputKey, inputValue) => {
+                  // -- If the input key is not a known property key (i.e. it was not specified in the struct) decode it with the rest parameter
+                  if (!hasOwn(properties, inputKey) || properties[inputKey] === undefined)
+                    return pipe(
+                      rest.decode(inputValue),
+                      E.bimap(
+                        A.concat<ValidationError>([
+                          {
+                            value: inputValue,
+                            context: [{ key: inputKey, type: rest }],
+                            message: 'Rest param failed to decode',
+                          },
+                        ]),
+                        result => O.some([result, inputKey]),
+                      ),
+                    )
+
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                  const { _keyRemap } = properties[inputKey]!
+
+                  // -- If the input key is a known property key (i.e. it was specified in the struct) keep its more precise value
+                  return keyIsNotMapped(_keyRemap)
+                    ? E.right(O.some([knownResult[inputKey], inputKey]))
+                    : E.right(O.some([knownResult[_keyRemap], _keyRemap]))
+                }),
+              ),
+            ),
+          )
+        }),
+        a => a as any,
+      ),
+      Encoder.structM(properties, params).encode,
     ) as any,
 }

--- a/src/schemables/WithStructM/type-utils.ts
+++ b/src/schemables/WithStructM/type-utils.ts
@@ -1,0 +1,95 @@
+/**
+ * Type utils for WithStructM
+ *
+ * @since 1.3.0
+ */
+import { HKT2, Kind, Kind2, URIS, URIS2 } from 'fp-ts/HKT'
+import { KeyNotMapped, OptionalKeyFlag, RequiredKeyFlag } from 'schemata-ts/struct'
+/* eslint-disable @typescript-eslint/ban-types */
+
+/** @since 1.3.0 */
+export type OptionalProps<T> = {
+  [K in keyof T]: T[K] extends { readonly _flag: OptionalKeyFlag } ? K : never
+}[keyof T]
+
+/** @since 1.3.0 */
+export type RequiredProps<T> = {
+  [K in keyof T]: T[K] extends { readonly _flag: RequiredKeyFlag } ? K : never
+}[keyof T]
+
+/** @since 1.3.0 */
+export type RemapKey<KeyIn, Prop> = Prop extends { readonly _keyRemap: infer KeyOut }
+  ? KeyOut extends KeyNotMapped
+    ? KeyIn
+    : KeyOut
+  : never
+
+/** @since 1.3.0 */
+export type InnerValue1<S extends URIS, Prop> = Prop extends {
+  readonly _val: infer Val
+}
+  ? Val extends Kind<S, infer A>
+    ? A
+    : never
+  : never
+
+/** @since 1.3.0 */
+export type RestValue1<S extends URIS, RestKind> = RestKind extends undefined
+  ? unknown
+  : { [key: string]: RestKind extends Kind<S, infer A> ? A : never } | {}
+
+/** @since 1.3.0 */
+export type InputHKT2<S, Prop> = Prop extends {
+  readonly _val: infer Val
+}
+  ? Val extends HKT2<S, infer E, any>
+    ? E
+    : never
+  : never
+
+/** @since 1.3.0 */
+export type OutputHKT2<S, Prop> = Prop extends {
+  readonly _val: infer Val
+}
+  ? Val extends HKT2<S, any, infer A>
+    ? A
+    : never
+  : never
+
+/** @since 1.3.0 */
+export type RestInputHKT2<S, RestKind> = RestKind extends undefined
+  ? unknown
+  : { [key: string]: RestKind extends HKT2<S, infer E, any> ? E : never } | {}
+
+/** @since 1.3.0 */
+export type RestOutputHKT2<S, RestKind> = RestKind extends undefined
+  ? unknown
+  : { [key: string]: RestKind extends HKT2<S, any, infer A> ? A : never } | {}
+
+/** @since 1.3.0 */
+export type Input2<S extends URIS2, Prop> = Prop extends {
+  readonly _val: infer Val
+}
+  ? Val extends Kind2<S, infer E, any>
+    ? E
+    : never
+  : never
+
+/** @since 1.3.0 */
+export type Output2<S extends URIS2, Prop> = Prop extends {
+  readonly _val: infer Val
+}
+  ? Val extends Kind2<S, any, infer A>
+    ? A
+    : never
+  : never
+
+/** @since 1.3.0 */
+export type RestInput2<S extends URIS2, RestKind> = RestKind extends undefined
+  ? unknown
+  : { [key: string]: RestKind extends Kind2<S, infer E, any> ? E : never } | {}
+
+/** @since 1.3.0 */
+export type RestOutput2<S extends URIS2, RestKind> = RestKind extends undefined
+  ? unknown
+  : { [key: string]: RestKind extends Kind2<S, any, infer A> ? A : never } | {}

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -1,0 +1,267 @@
+/**
+ * A meta definition for a struct for use with `StructM` schema
+ *
+ * @since 1.3.0
+ */
+import { identity } from 'fp-ts/function'
+import { HKT2, Kind, Kind2, URIS, URIS2 } from 'fp-ts/HKT'
+import { URI } from 'schemata-ts/base/SchemaBase'
+
+/**
+ * @since 1.3.0
+ * @category Model
+ */
+export type OptionalKeyFlag = typeof OptionalKeyFlag
+const OptionalKeyFlag = Symbol()
+
+/**
+ * @since 1.3.0
+ * @category Model
+ */
+export type RequiredKeyFlag = typeof RequiredKeyFlag
+const RequiredKeyFlag = Symbol()
+
+/**
+ * @since 1.3.0
+ * @category Model
+ */
+export type KeyNotMapped = typeof KeyNotMapped
+const KeyNotMapped = Symbol()
+
+/**
+ * @since 1.3.0
+ * @category Model
+ */
+export type KeyFlag = OptionalKeyFlag | RequiredKeyFlag
+
+/**
+ * Meta information for an HKT2 for if the key is optional or required, and if the key is remapped
+ *
+ * @since 1.3.0
+ * @category Model
+ */
+export interface Prop<
+  Flag extends KeyFlag,
+  S,
+  Val extends HKT2<S, any, any>,
+  K extends string | KeyNotMapped,
+> {
+  readonly _flag: Flag
+  readonly _keyRemap: K
+  readonly _val: Val
+}
+
+/**
+ * Meta information for a Kind for if the key is optional or required, and if the key is remapped
+ *
+ * @since 1.3.0
+ * @category Model
+ */
+export interface Prop1<
+  Flag extends KeyFlag,
+  S extends URIS,
+  Val extends Kind<S, any>,
+  K extends string | KeyNotMapped,
+> {
+  readonly _flag: Flag
+  readonly _keyRemap: K
+  readonly _val: Val
+}
+
+/**
+ * Meta information for a Kind2 for if the key is optional or required, and if the key is remapped
+ *
+ * @since 1.3.0
+ * @category Model
+ */
+export interface Prop2<
+  Flag extends KeyFlag,
+  S extends URIS2,
+  Val extends Kind2<S, any, any>,
+  K extends string | KeyNotMapped,
+> {
+  readonly _flag: Flag
+  readonly _keyRemap: K
+  readonly _val: Val
+}
+
+type Required = {
+  /**
+   * Used to indicate that a property is required
+   *
+   * @since 1.3.0
+   */
+  <S extends URIS2, Val extends Kind2<S, any, any>>(val: Val): Prop2<
+    RequiredKeyFlag,
+    S,
+    Val,
+    KeyNotMapped
+  >
+  /**
+   * Used to indicate that a property is required
+   *
+   * @since 1.3.0
+   */
+  <S extends URIS, Val extends Kind<S, any>>(val: Val): Prop1<
+    RequiredKeyFlag,
+    S,
+    Val,
+    KeyNotMapped
+  >
+  /**
+   * Used to indicate that a property is required
+   *
+   * @since 1.3.0
+   */
+  <S, Val extends HKT2<S, any, any>>(val: Val): Prop<
+    RequiredKeyFlag,
+    S,
+    Val,
+    KeyNotMapped
+  >
+}
+
+/**
+ * Indicates that a property is required
+ *
+ * @since 1.3.0
+ * @category Constructors
+ */
+export const requiredProp: Required = (val: any) =>
+  ({
+    _flag: RequiredKeyFlag,
+    _keyRemap: KeyNotMapped,
+    _val: val,
+  } as any)
+
+/**
+ * @since 1.3.0
+ * @category Guards
+ */
+export const isRequiredFlag = (flag: KeyFlag): flag is RequiredKeyFlag =>
+  flag === RequiredKeyFlag
+
+type Optional = {
+  /**
+   * Used to indicate that a property is optional
+   *
+   * @since 1.3.0
+   */
+  <S extends URIS2, Val extends Kind2<S, any, any>>(val: Val): Prop2<
+    OptionalKeyFlag,
+    S,
+    Val,
+    KeyNotMapped
+  >
+  /**
+   * Used to indicate that a property is optional
+   *
+   * @since 1.3.0
+   */
+  <S extends URIS, Val extends Kind<S, any>>(val: Val): Prop1<
+    OptionalKeyFlag,
+    S,
+    Val,
+    KeyNotMapped
+  >
+  /**
+   * Used to indicate that a property is optional
+   *
+   * @since 1.3.0
+   */
+  <S, Val extends HKT2<S, any, any>>(val: Val): Prop<
+    OptionalKeyFlag,
+    S,
+    Val,
+    KeyNotMapped
+  >
+}
+
+/**
+ * Indicates that a property is optional
+ *
+ * @since 1.3.0
+ * @category Constructors
+ */
+export const optionalProp: Optional = (val: any) =>
+  ({
+    _flag: OptionalKeyFlag,
+    _keyRemap: KeyNotMapped,
+    _val: val,
+  } as any)
+
+type MapKeyTo = {
+  /**
+   * Used to remap a property's key to a new key in the output type
+   *
+   * @since 1.3.0
+   */
+  <K extends string>(mapTo: K): <
+    Flag extends KeyFlag,
+    S extends URIS2,
+    Val extends Kind2<S, any, any>,
+  >(
+    prop: Prop2<Flag, S, Val, KeyNotMapped>,
+  ) => Prop2<Flag, S, Val, K>
+  /**
+   * Used to remap a property's key to a new key in the output type
+   *
+   * @since 1.3.0
+   */
+  <K extends string>(mapTo: K): <
+    Flag extends KeyFlag,
+    S extends URIS,
+    Val extends Kind<S, any>,
+  >(
+    prop: Prop1<Flag, S, Val, KeyNotMapped>,
+  ) => Prop1<Flag, S, Val, K>
+  /**
+   * Used to remap a property's key to a new key in the output type
+   *
+   * @since 1.3.0
+   */
+  <K extends string>(mapTo: K): <Flag extends KeyFlag, S, Val extends HKT2<S, any, any>>(
+    prop: Prop<Flag, S, Val, KeyNotMapped>,
+  ) => Prop<Flag, S, Val, K>
+}
+
+/**
+ * @since 1.3.0
+ * @category Guards
+ */
+export const isOptionalFlag = (flag: KeyFlag): flag is OptionalKeyFlag =>
+  flag === OptionalKeyFlag
+
+/**
+ * Used to remap a property's key to a new key in the output type
+ *
+ * @since 1.3.0
+ * @category Constructors
+ */
+export const mapKeyTo: MapKeyTo = mapTo => (prop: any) => ({
+  ...prop,
+  _keyRemap: mapTo,
+})
+
+/**
+ * @since 1.3.0
+ * @category Guards
+ */
+export const keyIsNotMapped = (key: string | KeyNotMapped): key is KeyNotMapped =>
+  key === KeyNotMapped
+
+/**
+ * @since 1.3.0
+ * @category Models
+ */
+export interface StructDefinition {
+  <Props extends Record<string, Prop2<KeyFlag, URI, any, string | KeyNotMapped>>>(
+    props: Props,
+  ): Props
+}
+
+/**
+ * @since 1.3.0
+ * @category Models
+ */
+export const defineStruct: StructDefinition = identity

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -126,7 +126,7 @@ interface Required {
  * @since 1.3.0
  * @category Constructors
  */
-export const requiredProp: Required = (val: any) =>
+export const required: Required = (val: any) =>
   ({
     _flag: RequiredKeyFlag,
     _keyRemap: KeyNotMapped,
@@ -182,7 +182,7 @@ interface Optional {
  * @since 1.3.0
  * @category Constructors
  */
-export const optionalProp: Optional = (val: any) =>
+export const optional: Optional = (val: any) =>
   ({
     _flag: OptionalKeyFlag,
     _keyRemap: KeyNotMapped,
@@ -235,7 +235,7 @@ export const isOptionalFlag = (flag: KeyFlag): flag is OptionalKeyFlag =>
  * Used to remap a property's key to a new key in the output type
  *
  * @since 1.3.0
- * @category Constructors
+ * @category Combinators
  */
 export const mapKeyTo: MapKeyTo = mapTo => (prop: any) => ({
   ...prop,
@@ -249,30 +249,267 @@ export const mapKeyTo: MapKeyTo = mapTo => (prop: any) => ({
 export const keyIsNotMapped = (key: string | KeyNotMapped): key is KeyNotMapped =>
   key === KeyNotMapped
 
-/**
- * @since 1.3.0
- * @category Models
- */
-export interface StructDefinition {
+interface StructDefinition {
+  /**
+   * A convenience function to declare reusable struct definitions with type-safety
+   * without first plugging into StructM
+   *
+   * @since 1.3.0
+   * @category Models
+   */
   <
     S extends URIS2,
-    Props extends Record<string, Prop2<KeyFlag, S, any, string | KeyNotMapped>>,
+    Props extends Record<
+      string,
+      Prop2<KeyFlag, S, Kind2<S, any, any>, string | KeyNotMapped>
+    >,
   >(
     props: Props,
   ): Props
+  /**
+   * A convenience function to declare reusable struct definitions with type-safety
+   * without first plugging into StructM
+   *
+   * @since 1.3.0
+   * @category Models
+   */
   <
     S extends URIS,
-    Props extends Record<string, Prop<KeyFlag, S, any, string | KeyNotMapped>>,
+    Props extends Record<string, Prop1<KeyFlag, S, Kind<S, any>, string | KeyNotMapped>>,
   >(
     props: Props,
   ): Props
-  <S, Props extends Record<string, Prop<KeyFlag, S, any, string | KeyNotMapped>>>(
+  /**
+   * A convenience function to declare reusable struct definitions with type-safety
+   * without first plugging into StructM
+   *
+   * @since 1.3.0
+   * @category Models
+   */
+  <
+    S,
+    Props extends Record<
+      string,
+      Prop<KeyFlag, S, HKT2<S, any, any>, string | KeyNotMapped>
+    >,
+  >(
     props: Props,
   ): Props
 }
 
 /**
  * @since 1.3.0
- * @category Models
+ * @category Constructors
  */
 export const defineStruct: StructDefinition = identity
+
+interface Partial {
+  /**
+   * Remap a StructM definition such that all keys are optional
+   *
+   * @since 1.3.0
+   * @category Models
+   */
+  <
+    S extends URIS2,
+    Props extends Record<
+      string,
+      Prop2<KeyFlag, S, Kind2<S, unknown, unknown>, string | KeyNotMapped>
+    >,
+  >(
+    props: Props,
+  ): {
+    [K in keyof Props]: Props[K] extends Prop2<any, any, infer Val, infer Remap>
+      ? Prop2<OptionalKeyFlag, S, Val, Remap>
+      : never
+  }
+  /**
+   * Remap a StructM definition such that all keys are optional
+   *
+   * @since 1.3.0
+   * @category Models
+   */
+  <
+    S extends URIS,
+    Props extends Record<
+      string,
+      Prop1<KeyFlag, S, Kind<S, unknown>, string | KeyNotMapped>
+    >,
+  >(
+    props: Props,
+  ): {
+    [K in keyof Props]: Props[K] extends Prop1<any, any, infer Val, infer Remap>
+      ? Prop1<OptionalKeyFlag, S, Val, Remap>
+      : never
+  }
+  /**
+   * Remap a StructM definition such that all keys are optional
+   *
+   * @since 1.3.0
+   * @category Models
+   */
+  <
+    S,
+    Props extends Record<
+      string,
+      Prop<KeyFlag, S, HKT2<S, unknown, unknown>, string | KeyNotMapped>
+    >,
+  >(
+    props: Props,
+  ): {
+    [K in keyof Props]: Props[K] extends Prop<any, any, infer Val, infer Remap>
+      ? Prop<OptionalKeyFlag, S, Val, Remap>
+      : never
+  }
+}
+
+/**
+ * Marks all properties as optional
+ *
+ * @since 1.3.0
+ * @category Utilities
+ */
+export const partial: Partial = (
+  props: Record<
+    string,
+    Prop<KeyFlag, URIS2, HKT2<URIS2, unknown, unknown>, string | KeyNotMapped>
+  >,
+) => {
+  const result: Record<
+    string,
+    Prop<KeyFlag, URIS2, HKT2<URIS2, unknown, unknown>, string | KeyNotMapped>
+  > = {}
+  for (const key in props) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const prop = props[key]!
+    result[key] = { ...prop, _flag: OptionalKeyFlag }
+  }
+  return result as any
+}
+
+interface Complete {
+  /**
+   * Remap a StructM definition such that all keys are required
+   *
+   * @since 1.3.0
+   * @category Models
+   */
+  <
+    S extends URIS2,
+    Props extends Record<
+      string,
+      Prop2<KeyFlag, S, Kind2<S, unknown, unknown>, string | KeyNotMapped>
+    >,
+  >(
+    props: Props,
+  ): {
+    [K in keyof Props]: Props[K] extends Prop2<any, any, infer Val, infer Remap>
+      ? Prop2<RequiredKeyFlag, S, Val, Remap>
+      : never
+  }
+  /**
+   * Remap a StructM definition such that all keys are required
+   *
+   * @since 1.3.0
+   * @category Models
+   */
+  <
+    S extends URIS,
+    Props extends Record<
+      string,
+      Prop1<KeyFlag, S, Kind<S, unknown>, string | KeyNotMapped>
+    >,
+  >(
+    props: Props,
+  ): {
+    [K in keyof Props]: Props[K] extends Prop1<any, any, infer Val, infer Remap>
+      ? Prop1<RequiredKeyFlag, S, Val, Remap>
+      : never
+  }
+  /**
+   * Remap a StructM definition such that all keys are required
+   *
+   * @since 1.3.0
+   * @category Models
+   */
+  <
+    S,
+    Props extends Record<
+      string,
+      Prop<KeyFlag, S, HKT2<S, unknown, unknown>, string | KeyNotMapped>
+    >,
+  >(
+    props: Props,
+  ): {
+    [K in keyof Props]: Props[K] extends Prop<any, any, infer Val, infer Remap>
+      ? Prop<RequiredKeyFlag, S, Val, Remap>
+      : never
+  }
+}
+
+/**
+ * Marks all properties as required.
+ *
+ * @since 1.3.0
+ * @category Utilities
+ */
+export const complete: Complete = (
+  props: Record<
+    string,
+    Prop<KeyFlag, URIS2, HKT2<URIS2, unknown, unknown>, string | KeyNotMapped>
+  >,
+) => {
+  const result: Record<
+    string,
+    Prop<KeyFlag, URIS2, HKT2<URIS2, unknown, unknown>, string | KeyNotMapped>
+  > = {}
+  for (const key in props) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const prop = props[key]!
+    result[key] = { ...prop, _flag: RequiredKeyFlag }
+  }
+  return result as any
+}
+
+/**
+ * Include only a specified set of keys of an object. Built for StructM but works with any struct
+ *
+ * @since 1.3.0
+ * @category Utilities
+ */
+export const pick =
+  <
+    A extends Record<string, unknown>,
+    Keys extends [keyof A, ...ReadonlyArray<Exclude<keyof A, Keys[0]>>],
+  >(
+    ...keys: Keys
+  ) =>
+  (obj: A): { [K in Keys[number]]: A[K] } => {
+    const result: any = {}
+    for (const key of keys) {
+      result[key] = obj[key]
+    }
+    return result
+  }
+
+/**
+ * Exclude a set of keys from an object. Built for StructM but works with any struct
+ *
+ * @since 1.3.0
+ * @category Utilities
+ */
+export const omit: <
+  A extends Record<string, unknown>,
+  Keys extends [keyof A, ...ReadonlyArray<Exclude<keyof A, Keys[0]>>],
+>(
+  ...omittedKeys: Keys
+) => (obj: A) => { [K in Exclude<keyof A, Keys[number]>]: A[K] } = (...omittedKeys) => {
+  return obj => {
+    const result: any = {}
+    for (const key in obj) {
+      if (omittedKeys.includes(key)) continue
+      result[key] = obj[key]
+    }
+    return result
+  }
+}

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -5,21 +5,20 @@
  */
 import { identity } from 'fp-ts/function'
 import { HKT2, Kind, Kind2, URIS, URIS2 } from 'fp-ts/HKT'
-import { URI } from 'schemata-ts/base/SchemaBase'
 
 /**
  * @since 1.3.0
  * @category Model
  */
-export type OptionalKeyFlag = typeof OptionalKeyFlag
-const OptionalKeyFlag = Symbol()
+export type OptionalKeyFlag = 'Optional'
+const OptionalKeyFlag: OptionalKeyFlag = 'Optional'
 
 /**
  * @since 1.3.0
  * @category Model
  */
-export type RequiredKeyFlag = typeof RequiredKeyFlag
-const RequiredKeyFlag = Symbol()
+export type RequiredKeyFlag = 'Required'
+const RequiredKeyFlag: RequiredKeyFlag = 'Required'
 
 /**
  * @since 1.3.0
@@ -85,7 +84,7 @@ export interface Prop2<
   readonly _val: Val
 }
 
-type Required = {
+interface Required {
   /**
    * Used to indicate that a property is required
    *
@@ -141,7 +140,7 @@ export const requiredProp: Required = (val: any) =>
 export const isRequiredFlag = (flag: KeyFlag): flag is RequiredKeyFlag =>
   flag === RequiredKeyFlag
 
-type Optional = {
+interface Optional {
   /**
    * Used to indicate that a property is optional
    *
@@ -190,7 +189,7 @@ export const optionalProp: Optional = (val: any) =>
     _val: val,
   } as any)
 
-type MapKeyTo = {
+interface MapKeyTo {
   /**
    * Used to remap a property's key to a new key in the output type
    *
@@ -255,7 +254,19 @@ export const keyIsNotMapped = (key: string | KeyNotMapped): key is KeyNotMapped 
  * @category Models
  */
 export interface StructDefinition {
-  <Props extends Record<string, Prop2<KeyFlag, URI, any, string | KeyNotMapped>>>(
+  <
+    S extends URIS2,
+    Props extends Record<string, Prop2<KeyFlag, S, any, string | KeyNotMapped>>,
+  >(
+    props: Props,
+  ): Props
+  <
+    S extends URIS,
+    Props extends Record<string, Prop<KeyFlag, S, any, string | KeyNotMapped>>,
+  >(
+    props: Props,
+  ): Props
+  <S, Props extends Record<string, Prop<KeyFlag, S, any, string | KeyNotMapped>>>(
     props: Props,
   ): Props
 }

--- a/tests/schemables/WithStructM.test.ts
+++ b/tests/schemables/WithStructM.test.ts
@@ -24,24 +24,27 @@ import { Eq } from '../../src/schemables/WithStructM/instances/eq'
 import { Guard } from '../../src/schemables/WithStructM/instances/guard'
 import { JsonSchema } from '../../src/schemables/WithStructM/instances/json-schema'
 import { Printer } from '../../src/schemables/WithStructM/instances/printer'
-import { defineStruct } from '../../src/schemables/WithStructM/instances/schema'
 import { TaskDecoder } from '../../src/schemables/WithStructM/instances/task-decoder'
 import { Type } from '../../src/schemables/WithStructM/instances/type'
 import * as S from '../../src/schemata'
+import * as s from '../../src/struct'
 
 const decodeOptionFromNullableDateFromUnix = getDecoder(
   S.OptionFromNullable(S.DateFromUnixTime),
 )
 const decodeOptionFromNullableString = getDecoder(S.OptionFromNullable(S.String))
 
+const abc = s.defineStruct({
+  a: s.requiredProp(S.String),
+  b: s.optionalProp(S.Number),
+  c: s.mapKeyTo('d')(s.requiredProp(S.Boolean)),
+})
+
+const ABC = S.StructM(abc)
+
 describe("type-level 'WithStructM' instances", () => {
-  const testStruct = S.StructM(_ => ({
-    a: _.required(S.String),
-    b: _.optional(S.Number),
-    c: pipe(_.required(S.Boolean), _.mapKeyTo('d')),
-  }))
   test('decoder', () => {
-    const decoder = getDecoder(testStruct)
+    const decoder = getDecoder(ABC)
     expectTypeOf<typeof decoder>().toEqualTypeOf<
       D.Decoder<
         unknown,
@@ -54,7 +57,7 @@ describe("type-level 'WithStructM' instances", () => {
     >()
   })
   test('encoder', () => {
-    const encoder = getEncoder(testStruct)
+    const encoder = getEncoder(ABC)
     expectTypeOf<typeof encoder>().toEqualTypeOf<
       Enc.Encoder<
         {
@@ -71,7 +74,7 @@ describe("type-level 'WithStructM' instances", () => {
     >()
   })
   test('guard', () => {
-    const guard = getGuard(testStruct)
+    const guard = getGuard(ABC)
     expectTypeOf<typeof guard>().toEqualTypeOf<
       G.Guard<
         unknown,
@@ -87,12 +90,7 @@ describe("type-level 'WithStructM' instances", () => {
 
 describe('WithStructM', () => {
   describe('Schema', () => {
-    const SomeStructSchemaBase = defineStruct(_ => ({
-      a: _.required(S.String),
-      b: _.optional(S.Number),
-      c: pipe(_.required(S.Boolean), _.mapKeyTo('d')),
-    }))
-    const SomeStructSchema = S.StructM(SomeStructSchemaBase)
+    const SomeStructSchema = S.StructM(abc)
 
     it('should decode a struct with required and optional properties', () => {
       const decode = getDecoder(SomeStructSchema)
@@ -104,7 +102,7 @@ describe('WithStructM', () => {
 
     it('should decode with a rest param', () => {
       const decode = getDecoder(
-        S.StructM(SomeStructSchemaBase, {
+        S.StructM(abc, {
           extraProps: 'restParam',
           restParam: S.Natural,
         }),
@@ -119,11 +117,13 @@ describe('WithStructM', () => {
   })
   describe('Printer', () => {
     it('should print a struct with required and optional properties with remapping', () => {
-      const printer = Printer.structM(_ => ({
-        a: _.required(P.string),
-        b: _.optional(P.number),
-        c: pipe(_.required(P.boolean), _.mapKeyTo('d')),
-      }))
+      const printer = Printer.structM(
+        s.defineStruct({
+          a: s.requiredProp(P.string),
+          b: s.optionalProp(P.number),
+          c: s.mapKeyTo('d')(s.requiredProp(P.boolean)),
+        }),
+      )
       expect(printer.codomainToJson({ a: 'a', b: 1, c: true })).toEqual(
         E.right({
           a: 'a',
@@ -137,10 +137,10 @@ describe('WithStructM', () => {
     })
     it('strips with extraProps: error', () => {
       const printer = Printer.structM(
-        _ => ({
-          a: _.required(P.string),
-          b: _.optional(P.number),
-          c: pipe(_.required(P.boolean), _.mapKeyTo('d')),
+        s.defineStruct({
+          a: s.requiredProp(P.string),
+          b: s.optionalProp(P.number),
+          c: s.mapKeyTo('d')(s.requiredProp(P.boolean)),
         }),
         { extraProps: 'error' },
       )
@@ -160,10 +160,10 @@ describe('WithStructM', () => {
     })
     it('acts like strip for undefined restParam', () => {
       const printer = Printer.structM(
-        _ => ({
-          a: _.required(P.string),
-          b: _.optional(P.number),
-          c: pipe(_.required(P.boolean), _.mapKeyTo('d')),
+        s.defineStruct({
+          a: s.requiredProp(P.string),
+          b: s.optionalProp(P.number),
+          c: s.mapKeyTo('d')(s.requiredProp(P.boolean)),
         }),
         { extraProps: 'restParam', restParam: undefined },
       )
@@ -180,13 +180,13 @@ describe('WithStructM', () => {
     })
     it('should print a struct with required and optional properties and additional properties', () => {
       const printer = Printer.structM(
-        _ => ({
-          a: _.required(P.string),
-          b: _.optional(P.number),
+        {
+          a: s.requiredProp(P.string),
+          b: s.optionalProp(P.number),
           __proto__: {
-            c: _.required(P.boolean),
+            c: s.requiredProp(P.boolean),
           } as any,
-        }),
+        },
         { extraProps: 'restParam', restParam: P.boolean },
       )
       expect(printer.domainToJson({ a: 'a', b: 1, rest: true })).toEqual(
@@ -207,10 +207,10 @@ describe('WithStructM', () => {
   })
   describe('JsonSchema', () => {
     it('should return a json schema for a struct with required and optional properties', () => {
-      const jsonSchema = JsonSchema.structM(_ => ({
-        a: _.required(JS.makeStringSchema()),
-        b: _.optional(JS.makeNumberSchema()),
-      }))
+      const jsonSchema = JsonSchema.structM({
+        a: s.requiredProp(JS.makeStringSchema()),
+        b: s.optionalProp(JS.makeNumberSchema()),
+      })
       expect(JS.stripIdentity(jsonSchema)).toEqual({
         type: 'object',
         properties: {
@@ -222,10 +222,10 @@ describe('WithStructM', () => {
     })
     it('should return a json schema for a struct with required and optional properties and additional properties', () => {
       const jsonSchema = JsonSchema.structM(
-        _ => ({
-          a: _.required(JS.makeStringSchema()),
-          b: _.optional(JS.makeNumberSchema()),
-        }),
+        {
+          a: s.requiredProp(JS.makeStringSchema()),
+          b: s.optionalProp(JS.makeNumberSchema()),
+        },
         { extraProps: 'restParam', restParam: JS.booleanSchema },
       )
       expect(JS.stripIdentity(jsonSchema)).toEqual({
@@ -240,10 +240,10 @@ describe('WithStructM', () => {
     })
     it('should return a json schema for a struct with no allowed additional params', () => {
       const jsonSchema = JsonSchema.structM(
-        _ => ({
-          a: _.required(JS.makeStringSchema()),
-          b: _.optional(JS.makeNumberSchema()),
-        }),
+        {
+          a: s.requiredProp(JS.makeStringSchema()),
+          b: s.optionalProp(JS.makeNumberSchema()),
+        },
         {
           extraProps: 'error',
         },
@@ -261,70 +261,70 @@ describe('WithStructM', () => {
   })
   describe('Guard', () => {
     it('should guard a struct with required and optional properites', () => {
-      const guard = Guard.structM(_ => ({
-        a: _.required(G.Schemable.string),
-        b: pipe(_.optional(G.Schemable.number), _.mapKeyTo('d')),
-        c: pipe(_.required(G.Schemable.boolean), _.mapKeyTo('d')),
-      }))
+      const guard = Guard.structM({
+        a: s.requiredProp(G.Schemable.string),
+        b: pipe(s.optionalProp(G.Schemable.number), s.mapKeyTo('d')),
+        c: pipe(s.requiredProp(G.Schemable.boolean), s.mapKeyTo('d')),
+      })
       expect(guard.is({ a: 'a', c: true })).toBe(false)
       expect(guard.is({ a: 'a', d: true })).toBe(true)
       expect(guard.is({ a: 'a', b: 1, c: false })).toBe(false)
       expect(guard.is({ a: 'a', b: 1, d: false })).toBe(true)
     })
     it('should guard with a custom key remap', () => {
-      const guard = Guard.structM(_ => ({
-        a: _.required(G.Schemable.string),
-        b: _.optional(G.Schemable.number),
-      }))
+      const guard = Guard.structM({
+        a: s.requiredProp(G.Schemable.string),
+        b: s.optionalProp(G.Schemable.number),
+      })
       expect(guard.is({ a: 'a' })).toBe(true)
       expect(guard.is({ a: 'a', b: 1 })).toBe(true)
     })
     it('should fail on extra props', () => {
       const guard = Guard.structM(
-        _ => ({
-          a: _.required(G.Schemable.string),
-          b: _.optional(G.Schemable.number),
-        }),
+        {
+          a: s.requiredProp(G.Schemable.string),
+          b: s.optionalProp(G.Schemable.number),
+        },
         { extraProps: 'error' },
       )
       expect(guard.is({ a: 'a', b: 1, c: 'c' })).toBe(false)
     })
     it('acts like strip with undefined restParam', () => {
       const guard = Guard.structM(
-        _ => ({
-          a: _.required(G.Schemable.string),
-          b: _.optional(G.Schemable.number),
-        }),
+        {
+          a: s.requiredProp(G.Schemable.string),
+          b: s.optionalProp(G.Schemable.number),
+        },
         { extraProps: 'restParam', restParam: undefined },
       )
       expect(guard.is({ a: 'a', b: 1, c: 'c' })).toBe(true)
     })
     it('should pass with no extra props', () => {
       const guard = Guard.structM(
-        _ => ({
-          a: _.required(G.Schemable.string),
-          b: _.optional(G.Schemable.number),
-        }),
+        {
+          a: s.requiredProp(G.Schemable.string),
+          b: s.optionalProp(G.Schemable.number),
+        },
         { extraProps: 'error' },
       )
       expect(guard.is({ a: 'a', b: 1 })).toBe(true)
     })
     it('should fail on bad rest params', () => {
       const guard = Guard.structM(
-        _ => ({
-          a: _.required(G.Schemable.string),
-          b: _.optional(G.Schemable.number),
-        }),
+        {
+          a: s.requiredProp(G.Schemable.string),
+          b: s.optionalProp(G.Schemable.number),
+        },
         { extraProps: 'restParam', restParam: G.Schemable.boolean },
       )
       expect(guard.is({ a: 'a', b: 1, c: 'c' })).toBe(false)
     })
     it('should guard with rest params', () => {
       const guard = Guard.structM(
-        _ => ({
-          a: _.required(G.Schemable.string),
-          b: _.optional(G.Schemable.number),
-        }),
+        {
+          a: s.requiredProp(G.Schemable.string),
+          b: s.optionalProp(G.Schemable.number),
+        },
         { extraProps: 'restParam', restParam: G.Schemable.boolean },
       )
       expect(guard.is({ a: 'a', b: 1, c: true })).toBe(true)
@@ -332,37 +332,37 @@ describe('WithStructM', () => {
   })
   describe('Eq', () => {
     it('should be true for the same object', () => {
-      const eq = Eq.structM(_ => ({
-        a: _.required(Eq_.number),
-        b: _.optional(Eq_.string),
-      }))
+      const eq = Eq.structM({
+        a: s.requiredProp(Eq_.number),
+        b: s.optionalProp(Eq_.string),
+      })
       const a = { a: 1, b: '2' }
       expect(eq.equals(a, a)).toBe(true)
     })
     it('should be true for two equal objects', () => {
-      const eq = Eq.structM(_ => ({
-        a: _.required(Eq_.number),
-        b: _.optional(Eq_.string),
-      }))
+      const eq = Eq.structM({
+        a: s.requiredProp(Eq_.number),
+        b: s.optionalProp(Eq_.string),
+      })
       const a = { a: 1, b: '2' }
       const b = { a: 1, b: '2' }
       expect(eq.equals(a, b)).toBe(true)
     })
     it('should be false for two different objects', () => {
-      const eq = Eq.structM(_ => ({
-        a: _.required(Eq_.number),
-        b: _.optional(Eq_.string),
-      }))
+      const eq = Eq.structM({
+        a: s.requiredProp(Eq_.number),
+        b: s.optionalProp(Eq_.string),
+      })
       const a = { a: 1, b: '2' }
       const b = { a: 1, b: '3' }
       expect(eq.equals(a, b)).toBe(false)
     })
     it('should be true with rest params', () => {
       const eq = Eq.structM(
-        _ => ({
-          a: _.required(Eq_.number),
-          b: _.optional(Eq_.string),
-        }),
+        {
+          a: s.requiredProp(Eq_.number),
+          b: s.optionalProp(Eq_.string),
+        },
         { extraProps: 'restParam', restParam: Eq_.array(Eq_.boolean) },
       )
       const a = { a: 1, b: '2', c: [true, false] }
@@ -371,10 +371,10 @@ describe('WithStructM', () => {
     })
     it('should be false with rest params', () => {
       const eq = Eq.structM(
-        _ => ({
-          a: _.required(Eq_.number),
-          b: _.optional(Eq_.string),
-        }),
+        {
+          a: s.requiredProp(Eq_.number),
+          b: s.optionalProp(Eq_.string),
+        },
         { extraProps: 'restParam', restParam: Eq_.array(Eq_.boolean) },
       )
       const a = { a: 1, b: '2', c: [true, false] }
@@ -383,10 +383,10 @@ describe('WithStructM', () => {
     })
     it('fails fast for different number of keys', () => {
       const eq = Eq.structM(
-        _ => ({
-          a: _.required(Eq_.number),
-          b: _.optional(Eq_.string),
-        }),
+        {
+          a: s.requiredProp(Eq_.number),
+          b: s.optionalProp(Eq_.string),
+        },
         { extraProps: 'restParam', restParam: Eq_.nullable(Eq_.boolean) },
       )
       expect(
@@ -395,10 +395,10 @@ describe('WithStructM', () => {
     })
     it('fails fast for xKey not in y', () => {
       const eq = Eq.structM(
-        _ => ({
-          a: _.required(Eq_.number),
-          b: _.optional(Eq_.string),
-        }),
+        {
+          a: s.requiredProp(Eq_.number),
+          b: s.optionalProp(Eq_.string),
+        },
         { extraProps: 'restParam', restParam: Eq_.nullable(Eq_.boolean) },
       )
       expect(
@@ -408,19 +408,19 @@ describe('WithStructM', () => {
   })
   describe('Encoder', () => {
     it('encodes a struct with required and optional properites', () => {
-      const encoder = Encoder.structM(_ => ({
-        a: _.required(Enc.Schemable.string),
-        b: _.optional(Enc.Schemable.number),
-      }))
+      const encoder = Encoder.structM({
+        a: s.requiredProp(Enc.Schemable.string),
+        b: s.optionalProp(Enc.Schemable.number),
+      })
       expect(encoder.encode({ a: 'a' })).toEqual({ a: 'a' })
       expect(encoder.encode({ a: 'a', b: 1 })).toEqual({ a: 'a', b: 1 })
     })
     it('encodes with a custom key remap', () => {
-      const encoder = Encoder.structM(_ => ({
-        a: _.required(Enc.Schemable.string),
-        b: _.optional(Enc.Schemable.number),
-        c: pipe(_.required(Enc.Schemable.string), _.mapKeyTo('d')),
-      }))
+      const encoder = Encoder.structM({
+        a: s.requiredProp(Enc.Schemable.string),
+        b: s.optionalProp(Enc.Schemable.number),
+        c: pipe(s.requiredProp(Enc.Schemable.string), s.mapKeyTo('d')),
+      })
       expect(encoder.encode({ a: 'a', d: 'used-to-be-c' })).toEqual({
         a: 'a',
         c: 'used-to-be-c',
@@ -428,11 +428,11 @@ describe('WithStructM', () => {
     })
     it('encodes with a custom key remap and a rest param', () => {
       const encoder = Encoder.structM(
-        _ => ({
-          a: _.required(Enc.Schemable.string),
-          b: _.optional(Enc.Schemable.number),
-          c: pipe(_.required(Enc.Schemable.string), _.mapKeyTo('d')),
-        }),
+        {
+          a: s.requiredProp(Enc.Schemable.string),
+          b: s.optionalProp(Enc.Schemable.number),
+          c: pipe(s.requiredProp(Enc.Schemable.string), s.mapKeyTo('d')),
+        },
         {
           extraProps: 'restParam',
           restParam: Enc.Schemable.array(Enc.Schemable.boolean),
@@ -457,17 +457,17 @@ describe('WithStructM', () => {
       })
     })
     it('strips additional props', () => {
-      const encoder = Encoder.structM(_ => ({
-        a: _.required(Enc.Schemable.string),
-        b: _.optional(Enc.Schemable.number),
-        c: pipe(_.required(Enc.Schemable.string), _.mapKeyTo('d')),
-      }))
+      const encoder = Encoder.structM({
+        a: s.requiredProp(Enc.Schemable.string),
+        b: s.optionalProp(Enc.Schemable.number),
+        c: pipe(s.requiredProp(Enc.Schemable.string), s.mapKeyTo('d')),
+      })
       const encoder2 = Encoder.structM(
-        _ => ({
-          a: _.required(Enc.Schemable.string),
-          b: _.optional(Enc.Schemable.number),
-          c: pipe(_.required(Enc.Schemable.string), _.mapKeyTo('d')),
-        }),
+        {
+          a: s.requiredProp(Enc.Schemable.string),
+          b: s.optionalProp(Enc.Schemable.number),
+          c: pipe(s.requiredProp(Enc.Schemable.string), s.mapKeyTo('d')),
+        },
         { extraProps: 'error' },
       )
       expect(
@@ -492,21 +492,21 @@ describe('WithStructM', () => {
       })
     })
     it("behaves in a good way when there's an intersection", () => {
-      const encoder = Encoder.structM(_ => ({
-        a: pipe(_.required(Enc.Schemable.number), _.mapKeyTo('c')),
-        b: _.optional(Enc.Schemable.number),
-        c: _.required(Enc.Schemable.string),
-      }))
+      const encoder = Encoder.structM({
+        a: pipe(s.requiredProp(Enc.Schemable.number), s.mapKeyTo('c')),
+        b: s.optionalProp(Enc.Schemable.number),
+        c: s.requiredProp(Enc.Schemable.string),
+      })
       expect(encoder.encode({ b: 1, c: 5 })).toEqual({ b: 1, c: 5 })
     })
     it('ignores inherited properties', () => {
-      const encoder = Encoder.structM(_ => ({
-        a: _.required(Enc.Schemable.string),
-        b: _.optional(Enc.Schemable.number),
+      const encoder = Encoder.structM({
+        a: s.requiredProp(Enc.Schemable.string),
+        b: s.optionalProp(Enc.Schemable.number),
         __proto__: {
           test: 'foo',
         } as any,
-      }))
+      })
       expect(encoder.encode({ a: 'a', b: 1, __proto__: { c: '5' } } as any)).toEqual({
         a: 'a',
         b: 1,
@@ -514,17 +514,17 @@ describe('WithStructM', () => {
     })
   })
   describe('TaskDecoder', () => {
-    const decoder = TaskDecoder.structM(_ => ({
-      a: _.required(TD.string),
-      b: _.optional(TD.number),
-    }))
+    const decoder = TaskDecoder.structM({
+      a: s.requiredProp(TD.string),
+      b: s.optionalProp(TD.number),
+    })
     // Here we're only taking the first union element if there is an intersection
     it("behaves as expected when there's an intersection", async () => {
-      const decoder = TaskDecoder.structM(_ => ({
-        a: pipe(_.required(TD.number), _.mapKeyTo('c')),
-        b: _.optional(TD.number),
-        c: _.required(TD.string),
-      }))
+      const decoder = TaskDecoder.structM({
+        a: pipe(s.requiredProp(TD.number), s.mapKeyTo('c')),
+        b: s.optionalProp(TD.number),
+        c: s.requiredProp(TD.string),
+      })
       expect(await decoder.decode({ a: 1, b: 1, c: 'c' })()).toEqual({
         _tag: 'Right',
         right: { b: 1, c: 'c' },
@@ -564,11 +564,11 @@ describe('WithStructM', () => {
       )
     })
     it('decodes with a custom key remap', async () => {
-      const decoder = TaskDecoder.structM(_ => ({
-        a: _.required(TD.string),
-        b: _.optional(TD.number),
-        c: pipe(_.required(TD.string), _.mapKeyTo('d')),
-      }))
+      const decoder = TaskDecoder.structM({
+        a: s.requiredProp(TD.string),
+        b: s.optionalProp(TD.number),
+        c: pipe(s.requiredProp(TD.string), s.mapKeyTo('d')),
+      })
       expect(await decoder.decode({ a: 'a', c: 'used-to-be-c' })()).toEqual({
         _tag: 'Right',
         right: { a: 'a', d: 'used-to-be-c' },
@@ -576,11 +576,11 @@ describe('WithStructM', () => {
     })
     it('decodes with a custom key remap and a rest param', async () => {
       const decoder = TaskDecoder.structM(
-        _ => ({
-          a: _.required(TD.string),
-          b: _.optional(TD.number),
-          c: pipe(_.required(TD.string), _.mapKeyTo('d')),
-        }),
+        {
+          a: s.requiredProp(TD.string),
+          b: s.optionalProp(TD.number),
+          c: pipe(s.requiredProp(TD.string), s.mapKeyTo('d')),
+        },
         { extraProps: 'restParam', restParam: TD.array(TD.boolean) },
       )
       expect(
@@ -606,11 +606,11 @@ describe('WithStructM', () => {
     })
     it('fails with invalid rest param', async () => {
       const decoder = TaskDecoder.structM(
-        _ => ({
-          a: _.required(TD.string),
-          b: _.optional(TD.number),
-          c: pipe(_.required(TD.string), _.mapKeyTo('d')),
-        }),
+        {
+          a: s.requiredProp(TD.string),
+          b: s.optionalProp(TD.number),
+          c: pipe(s.requiredProp(TD.string), s.mapKeyTo('d')),
+        },
         { extraProps: 'restParam', restParam: TD.array(TD.boolean) },
       )
       expect(
@@ -629,11 +629,11 @@ describe('WithStructM', () => {
     })
     it("doesn't fail without rest elements", async () => {
       const decoder = TaskDecoder.structM(
-        _ => ({
-          a: _.required(TD.string),
-          b: _.optional(TD.number),
-          c: pipe(_.required(TD.string), _.mapKeyTo('d')),
-        }),
+        {
+          a: s.requiredProp(TD.string),
+          b: s.optionalProp(TD.number),
+          c: pipe(s.requiredProp(TD.string), s.mapKeyTo('d')),
+        },
         { extraProps: 'restParam', restParam: TD.array(TD.boolean) },
       )
       expect(await decoder.decode({ a: 'a', c: 'used-to-be-c' })()).toEqual({
@@ -643,11 +643,11 @@ describe('WithStructM', () => {
     })
     it('fails on additional props', async () => {
       const decoder = TaskDecoder.structM(
-        _ => ({
-          a: _.required(TD.string),
-          b: _.optional(TD.number),
-          c: pipe(_.required(TD.string), _.mapKeyTo('d')),
-        }),
+        {
+          a: s.requiredProp(TD.string),
+          b: s.optionalProp(TD.number),
+          c: pipe(s.requiredProp(TD.string), s.mapKeyTo('d')),
+        },
         { extraProps: 'error' },
       )
       expect(
@@ -668,11 +668,11 @@ describe('WithStructM', () => {
     })
     it('acts like strip if restParam is undefined', async () => {
       const decoder = TaskDecoder.structM(
-        _ => ({
-          a: _.required(TD.string),
-          b: _.optional(TD.number),
-          c: pipe(_.required(TD.string), _.mapKeyTo('d')),
-        }),
+        {
+          a: s.requiredProp(TD.string),
+          b: s.optionalProp(TD.number),
+          c: pipe(s.requiredProp(TD.string), s.mapKeyTo('d')),
+        },
         { extraProps: 'restParam', restParam: undefined },
       )
       expect(
@@ -688,17 +688,17 @@ describe('WithStructM', () => {
     })
   })
   describe('Decoder', () => {
-    const decoder = Decoder.structM(_ => ({
-      a: _.required(D.string),
-      b: _.optional(D.number),
-    }))
+    const decoder = Decoder.structM({
+      a: s.requiredProp(D.string),
+      b: s.optionalProp(D.number),
+    })
     // Here we're only taking the first union element if there is an intersection
     it("behaves as expected when there's an intersection", () => {
-      const decoder = Decoder.structM(_ => ({
-        a: pipe(_.required(D.number), _.mapKeyTo('c')),
-        b: _.optional(D.number),
-        c: _.required(D.string),
-      }))
+      const decoder = Decoder.structM({
+        a: pipe(s.requiredProp(D.number), s.mapKeyTo('c')),
+        b: s.optionalProp(D.number),
+        c: s.requiredProp(D.string),
+      })
       expect(decoder.decode({ a: 1, b: 1, c: 'c' })).toEqual({
         _tag: 'Right',
         right: { b: 1, c: 'c' },
@@ -735,11 +735,11 @@ describe('WithStructM', () => {
       )
     })
     it('decodes with a custom key remap', () => {
-      const decoder = Decoder.structM(_ => ({
-        a: _.required(D.string),
-        b: _.optional(D.number),
-        c: pipe(_.required(D.string), _.mapKeyTo('d')),
-      }))
+      const decoder = Decoder.structM({
+        a: s.requiredProp(D.string),
+        b: s.optionalProp(D.number),
+        c: pipe(s.requiredProp(D.string), s.mapKeyTo('d')),
+      })
       expect(decoder.decode({ a: 'a', c: 'used-to-be-c' })).toEqual({
         _tag: 'Right',
         right: { a: 'a', d: 'used-to-be-c' },
@@ -747,11 +747,11 @@ describe('WithStructM', () => {
     })
     it('decodes with a custom key remap and a rest param', () => {
       const decoder = Decoder.structM(
-        _ => ({
-          a: _.required(D.string),
-          b: _.optional(D.number),
-          c: pipe(_.required(D.string), _.mapKeyTo('d')),
-        }),
+        {
+          a: s.requiredProp(D.string),
+          b: s.optionalProp(D.number),
+          c: pipe(s.requiredProp(D.string), s.mapKeyTo('d')),
+        },
         { extraProps: 'restParam', restParam: D.array(D.boolean) },
       )
       expect(
@@ -777,11 +777,11 @@ describe('WithStructM', () => {
     })
     it('fails with invalid rest param', () => {
       const decoder = Decoder.structM(
-        _ => ({
-          a: _.required(D.string),
-          b: _.optional(D.number),
-          c: pipe(_.required(D.string), _.mapKeyTo('d')),
-        }),
+        {
+          a: s.requiredProp(D.string),
+          b: s.optionalProp(D.number),
+          c: pipe(s.requiredProp(D.string), s.mapKeyTo('d')),
+        },
         { extraProps: 'restParam', restParam: D.array(D.boolean) },
       )
       expect(
@@ -800,11 +800,11 @@ describe('WithStructM', () => {
     })
     it("doesn't fail without rest elements", () => {
       const decoder = Decoder.structM(
-        _ => ({
-          a: _.required(D.string),
-          b: _.optional(D.number),
-          c: pipe(_.required(D.string), _.mapKeyTo('d')),
-        }),
+        {
+          a: s.requiredProp(D.string),
+          b: s.optionalProp(D.number),
+          c: pipe(s.requiredProp(D.string), s.mapKeyTo('d')),
+        },
         { extraProps: 'restParam', restParam: D.array(D.boolean) },
       )
       expect(decoder.decode({ a: 'a', c: 'used-to-be-c' })).toEqual({
@@ -814,11 +814,11 @@ describe('WithStructM', () => {
     })
     it('fails on additional props', () => {
       const decoder = Decoder.structM(
-        _ => ({
-          a: _.required(D.string),
-          b: _.optional(D.number),
-          c: pipe(_.required(D.string), _.mapKeyTo('d')),
-        }),
+        {
+          a: s.requiredProp(D.string),
+          b: s.optionalProp(D.number),
+          c: pipe(s.requiredProp(D.string), s.mapKeyTo('d')),
+        },
         { extraProps: 'error' },
       )
       expect(
@@ -839,11 +839,11 @@ describe('WithStructM', () => {
     })
     it('acts like strip if restParam is undefined', () => {
       const decoder = Decoder.structM(
-        _ => ({
-          a: _.required(D.string),
-          b: _.optional(D.number),
-          c: pipe(_.required(D.string), _.mapKeyTo('d')),
-        }),
+        {
+          a: s.requiredProp(D.string),
+          b: s.optionalProp(D.number),
+          c: pipe(s.requiredProp(D.string), s.mapKeyTo('d')),
+        },
         { extraProps: 'restParam', restParam: undefined },
       )
       expect(
@@ -859,9 +859,9 @@ describe('WithStructM', () => {
     })
     describe("Ethan's weird edge cases", () => {
       const decoder = Decoder.structM(
-        _ => ({
-          date: _.optional(decodeOptionFromNullableDateFromUnix),
-        }),
+        {
+          date: s.optionalProp(decodeOptionFromNullableDateFromUnix),
+        },
         { extraProps: 'restParam', restParam: decodeOptionFromNullableString },
       )
       it('decodes both params', () => {
@@ -915,18 +915,18 @@ describe('WithStructM', () => {
   })
   describe('Arbitrary', () => {
     it('generates valid values', () => {
-      const arbitrary = Arbitrary.structM(_ => ({
-        a: _.required(Arb.string),
-        b: _.optional(Arb.number),
-        c: pipe(_.required(Arb.string), _.mapKeyTo('d')),
+      const arbitrary = Arbitrary.structM({
+        a: s.requiredProp(Arb.string),
+        b: s.optionalProp(Arb.number),
+        c: pipe(s.requiredProp(Arb.string), s.mapKeyTo('d')),
         __proto__: { e: 'f' } as any,
-      }))
-      const guard = Guard.structM(_ => ({
-        a: _.required(G.string),
-        b: _.optional(G.number),
-        c: pipe(_.required(G.string), _.mapKeyTo('d')),
+      })
+      const guard = Guard.structM({
+        a: s.requiredProp(G.string),
+        b: s.optionalProp(G.number),
+        c: pipe(s.requiredProp(G.string), s.mapKeyTo('d')),
         __proto__: { e: 'f' } as any,
-      }))
+      })
       fc.assert(
         fc.property(arbitrary.arbitrary(fc), value => {
           expect(guard.is(value)).toBe(true)
@@ -935,19 +935,19 @@ describe('WithStructM', () => {
     })
     it('generates rest params', () => {
       const arbitrary = Arbitrary.structM(
-        _ => ({
-          a: _.required(Arb.string),
-          b: _.optional(Arb.number),
-          c: pipe(_.required(Arb.string), _.mapKeyTo('d')),
-        }),
+        {
+          a: s.requiredProp(Arb.string),
+          b: s.optionalProp(Arb.number),
+          c: pipe(s.requiredProp(Arb.string), s.mapKeyTo('d')),
+        },
         { extraProps: 'restParam', restParam: Arb.array(Arb.boolean) },
       )
       const guard = Guard.structM(
-        _ => ({
-          a: _.required(G.string),
-          b: _.optional(G.number),
-          c: pipe(_.required(G.string), _.mapKeyTo('d')),
-        }),
+        {
+          a: s.requiredProp(G.string),
+          b: s.optionalProp(G.number),
+          c: pipe(s.requiredProp(G.string), s.mapKeyTo('d')),
+        },
         { extraProps: 'restParam', restParam: G.array(G.boolean) },
       )
       fc.assert(
@@ -958,15 +958,178 @@ describe('WithStructM', () => {
     })
   })
   describe('Type', () => {
-    it("doesn't fail without rest elements", () => {
-      const decoder = Type.structM(() => ({}), {
-        extraProps: 'restParam',
-        restParam: t.array(t.boolean),
+    const decoder = Type.structM({
+      a: s.requiredProp(t.string),
+      b: s.optionalProp(t.number),
+    })
+    // Here we're only taking the first union element if there is an intersection
+    it("behaves as expected when there's an intersection", () => {
+      const decoder = Type.structM({
+        a: pipe(s.requiredProp(t.number), s.mapKeyTo('c')),
+        b: s.optionalProp(t.number),
+        c: s.requiredProp(t.string),
       })
-      expect(decoder.name).toBe('mappedStruct')
-      expect(decoder.decode('')).toEqual({
+      expect(decoder.decode({ a: 1, b: 1, c: 'c' })).toEqual({
+        _tag: 'Right',
+        right: { b: 1, c: 'c' },
+      })
+    })
+    it('decodes a struct with required and optional properites', () => {
+      expect(decoder.decode({ a: 'a' })).toEqual({ _tag: 'Right', right: { a: 'a' } })
+      expect(decoder.decode({ a: 'a', b: 1 })).toEqual({
+        _tag: 'Right',
+        right: { a: 'a', b: 1 },
+      })
+    })
+    it('returns a failure for missing required key', () => {
+      expect(decoder.decode({ b: 1 })).toEqual(
+        E.left(
+          expect.arrayContaining([
+            expect.objectContaining({ message: 'Missing Required Property' }),
+          ]),
+        ),
+      )
+    })
+    it('fails for invalid value in optional key', () => {
+      expect(decoder.decode({ a: 'a', b: 'b' })).toEqual(
+        E.left(
+          expect.arrayContaining([
+            expect.objectContaining({ message: 'Failed to decode property' }),
+          ]),
+        ),
+      )
+    })
+    it('fails for invalid value in required key', () => {
+      expect(decoder.decode({ a: 1, b: 1 })).toEqual(
+        E.left(
+          expect.arrayContaining([
+            expect.objectContaining({ message: 'Failed to decode property' }),
+          ]),
+        ),
+      )
+    })
+    it('decodes with a custom key remap', () => {
+      const decoder = Decoder.structM({
+        a: s.requiredProp(D.string),
+        b: s.optionalProp(D.number),
+        c: pipe(s.requiredProp(D.string), s.mapKeyTo('d')),
+      })
+      expect(decoder.decode({ a: 'a', c: 'used-to-be-c' })).toEqual({
+        _tag: 'Right',
+        right: { a: 'a', d: 'used-to-be-c' },
+      })
+    })
+    it('decodes with a custom key remap and a rest param', () => {
+      const decoder = Decoder.structM(
+        {
+          a: s.requiredProp(D.string),
+          b: s.optionalProp(D.number),
+          c: pipe(s.requiredProp(D.string), s.mapKeyTo('d')),
+        },
+        { extraProps: 'restParam', restParam: D.array(D.boolean) },
+      )
+      expect(
+        decoder.decode({
+          a: 'a',
+          c: 'used-to-be-c',
+          e: [true, false],
+          f: [false],
+          g: [],
+          h: [true, true, true],
+        }),
+      ).toEqual({
+        _tag: 'Right',
+        right: {
+          a: 'a',
+          d: 'used-to-be-c',
+          e: [true, false],
+          f: [false],
+          g: [],
+          h: [true, true, true],
+        },
+      })
+    })
+    it('fails with invalid rest param', () => {
+      const decoder = Type.structM(
+        {
+          a: s.requiredProp(t.string),
+          b: s.optionalProp(t.number),
+          c: pipe(s.requiredProp(t.string), s.mapKeyTo('d')),
+        },
+        { extraProps: 'restParam', restParam: t.array(t.boolean) },
+      )
+      expect(
+        decoder.decode({
+          a: 'a',
+          c: 'used-to-be-c',
+          e: [true, false],
+          f: [false],
+          g: [],
+          h: [true, true, true],
+          i: 1,
+        }),
+      ).toEqual(
+        E.left(
+          expect.arrayContaining([
+            expect.objectContaining({ message: 'Rest param failed to decode' }),
+          ]),
+        ),
+      )
+    })
+    it("doesn't fail without rest elements", () => {
+      const decoder = Type.structM(
+        {
+          a: s.requiredProp(t.string),
+          b: s.optionalProp(t.number),
+          c: pipe(s.requiredProp(t.string), s.mapKeyTo('d')),
+        },
+        { extraProps: 'restParam', restParam: t.array(t.boolean) },
+      )
+      expect(decoder.decode({ a: 'a', c: 'used-to-be-c' })).toEqual({
+        _tag: 'Right',
+        right: { a: 'a', d: 'used-to-be-c' },
+      })
+    })
+    it('fails on additional props', () => {
+      const decoder = Type.structM(
+        {
+          a: s.requiredProp(t.string),
+          b: s.optionalProp(t.number),
+          c: pipe(s.requiredProp(t.string), s.mapKeyTo('d')),
+        },
+        { extraProps: 'error' },
+      )
+      expect(
+        decoder.decode({
+          a: 'a',
+          c: 'used-to-be-c',
+          d: "what you're not supposed to be here",
+        }),
+      ).toEqual({
         _tag: 'Left',
-        left: [{ value: '', context: [], message: 'Type not implemented for StructM' }],
+        left: expect.arrayContaining([
+          expect.objectContaining({ message: 'Encountered additional property' }),
+        ]),
+      })
+    })
+    it('acts like strip if restParam is undefined', () => {
+      const decoder = Type.structM(
+        {
+          a: s.requiredProp(t.string),
+          b: s.optionalProp(t.number),
+          c: pipe(s.requiredProp(t.string), s.mapKeyTo('d')),
+        },
+        { extraProps: 'restParam', restParam: undefined },
+      )
+      expect(
+        decoder.decode({
+          a: 'a',
+          c: 'used-to-be-c',
+          d: "what you're not supposed to be here",
+        }),
+      ).toEqual({
+        _tag: 'Right',
+        right: { a: 'a', d: 'used-to-be-c' },
       })
     })
   })

--- a/tests/schemables/WithStructM.test.ts
+++ b/tests/schemables/WithStructM.test.ts
@@ -35,9 +35,9 @@ const decodeOptionFromNullableDateFromUnix = getDecoder(
 const decodeOptionFromNullableString = getDecoder(S.OptionFromNullable(S.String))
 
 const abc = s.defineStruct({
-  a: s.requiredProp(S.String),
-  b: s.optionalProp(S.Number),
-  c: s.mapKeyTo('d')(s.requiredProp(S.Boolean)),
+  a: s.required(S.String),
+  b: s.optional(S.Number),
+  c: s.mapKeyTo('d')(s.required(S.Boolean)),
 })
 
 const ABC = S.StructM(abc)
@@ -119,9 +119,9 @@ describe('WithStructM', () => {
     it('should print a struct with required and optional properties with remapping', () => {
       const printer = Printer.structM(
         s.defineStruct({
-          a: s.requiredProp(P.string),
-          b: s.optionalProp(P.number),
-          c: s.mapKeyTo('d')(s.requiredProp(P.boolean)),
+          a: s.required(P.string),
+          b: s.optional(P.number),
+          c: s.mapKeyTo('d')(s.required(P.boolean)),
         }),
       )
       expect(printer.codomainToJson({ a: 'a', b: 1, c: true })).toEqual(
@@ -138,9 +138,9 @@ describe('WithStructM', () => {
     it('strips with extraProps: error', () => {
       const printer = Printer.structM(
         s.defineStruct({
-          a: s.requiredProp(P.string),
-          b: s.optionalProp(P.number),
-          c: s.mapKeyTo('d')(s.requiredProp(P.boolean)),
+          a: s.required(P.string),
+          b: s.optional(P.number),
+          c: s.mapKeyTo('d')(s.required(P.boolean)),
         }),
         { extraProps: 'error' },
       )
@@ -161,9 +161,9 @@ describe('WithStructM', () => {
     it('acts like strip for undefined restParam', () => {
       const printer = Printer.structM(
         s.defineStruct({
-          a: s.requiredProp(P.string),
-          b: s.optionalProp(P.number),
-          c: s.mapKeyTo('d')(s.requiredProp(P.boolean)),
+          a: s.required(P.string),
+          b: s.optional(P.number),
+          c: s.mapKeyTo('d')(s.required(P.boolean)),
         }),
         { extraProps: 'restParam', restParam: undefined },
       )
@@ -181,10 +181,10 @@ describe('WithStructM', () => {
     it('should print a struct with required and optional properties and additional properties', () => {
       const printer = Printer.structM(
         {
-          a: s.requiredProp(P.string),
-          b: s.optionalProp(P.number),
+          a: s.required(P.string),
+          b: s.optional(P.number),
           __proto__: {
-            c: s.requiredProp(P.boolean),
+            c: s.required(P.boolean),
           } as any,
         },
         { extraProps: 'restParam', restParam: P.boolean },
@@ -208,8 +208,8 @@ describe('WithStructM', () => {
   describe('JsonSchema', () => {
     it('should return a json schema for a struct with required and optional properties', () => {
       const jsonSchema = JsonSchema.structM({
-        a: s.requiredProp(JS.makeStringSchema()),
-        b: s.optionalProp(JS.makeNumberSchema()),
+        a: s.required(JS.makeStringSchema()),
+        b: s.optional(JS.makeNumberSchema()),
       })
       expect(JS.stripIdentity(jsonSchema)).toEqual({
         type: 'object',
@@ -223,8 +223,8 @@ describe('WithStructM', () => {
     it('should return a json schema for a struct with required and optional properties and additional properties', () => {
       const jsonSchema = JsonSchema.structM(
         {
-          a: s.requiredProp(JS.makeStringSchema()),
-          b: s.optionalProp(JS.makeNumberSchema()),
+          a: s.required(JS.makeStringSchema()),
+          b: s.optional(JS.makeNumberSchema()),
         },
         { extraProps: 'restParam', restParam: JS.booleanSchema },
       )
@@ -241,8 +241,8 @@ describe('WithStructM', () => {
     it('should return a json schema for a struct with no allowed additional params', () => {
       const jsonSchema = JsonSchema.structM(
         {
-          a: s.requiredProp(JS.makeStringSchema()),
-          b: s.optionalProp(JS.makeNumberSchema()),
+          a: s.required(JS.makeStringSchema()),
+          b: s.optional(JS.makeNumberSchema()),
         },
         {
           extraProps: 'error',
@@ -262,9 +262,9 @@ describe('WithStructM', () => {
   describe('Guard', () => {
     it('should guard a struct with required and optional properites', () => {
       const guard = Guard.structM({
-        a: s.requiredProp(G.Schemable.string),
-        b: pipe(s.optionalProp(G.Schemable.number), s.mapKeyTo('d')),
-        c: pipe(s.requiredProp(G.Schemable.boolean), s.mapKeyTo('d')),
+        a: s.required(G.Schemable.string),
+        b: pipe(s.optional(G.Schemable.number), s.mapKeyTo('d')),
+        c: pipe(s.required(G.Schemable.boolean), s.mapKeyTo('d')),
       })
       expect(guard.is({ a: 'a', c: true })).toBe(false)
       expect(guard.is({ a: 'a', d: true })).toBe(true)
@@ -273,8 +273,8 @@ describe('WithStructM', () => {
     })
     it('should guard with a custom key remap', () => {
       const guard = Guard.structM({
-        a: s.requiredProp(G.Schemable.string),
-        b: s.optionalProp(G.Schemable.number),
+        a: s.required(G.Schemable.string),
+        b: s.optional(G.Schemable.number),
       })
       expect(guard.is({ a: 'a' })).toBe(true)
       expect(guard.is({ a: 'a', b: 1 })).toBe(true)
@@ -282,8 +282,8 @@ describe('WithStructM', () => {
     it('should fail on extra props', () => {
       const guard = Guard.structM(
         {
-          a: s.requiredProp(G.Schemable.string),
-          b: s.optionalProp(G.Schemable.number),
+          a: s.required(G.Schemable.string),
+          b: s.optional(G.Schemable.number),
         },
         { extraProps: 'error' },
       )
@@ -292,8 +292,8 @@ describe('WithStructM', () => {
     it('acts like strip with undefined restParam', () => {
       const guard = Guard.structM(
         {
-          a: s.requiredProp(G.Schemable.string),
-          b: s.optionalProp(G.Schemable.number),
+          a: s.required(G.Schemable.string),
+          b: s.optional(G.Schemable.number),
         },
         { extraProps: 'restParam', restParam: undefined },
       )
@@ -302,8 +302,8 @@ describe('WithStructM', () => {
     it('should pass with no extra props', () => {
       const guard = Guard.structM(
         {
-          a: s.requiredProp(G.Schemable.string),
-          b: s.optionalProp(G.Schemable.number),
+          a: s.required(G.Schemable.string),
+          b: s.optional(G.Schemable.number),
         },
         { extraProps: 'error' },
       )
@@ -312,8 +312,8 @@ describe('WithStructM', () => {
     it('should fail on bad rest params', () => {
       const guard = Guard.structM(
         {
-          a: s.requiredProp(G.Schemable.string),
-          b: s.optionalProp(G.Schemable.number),
+          a: s.required(G.Schemable.string),
+          b: s.optional(G.Schemable.number),
         },
         { extraProps: 'restParam', restParam: G.Schemable.boolean },
       )
@@ -322,8 +322,8 @@ describe('WithStructM', () => {
     it('should guard with rest params', () => {
       const guard = Guard.structM(
         {
-          a: s.requiredProp(G.Schemable.string),
-          b: s.optionalProp(G.Schemable.number),
+          a: s.required(G.Schemable.string),
+          b: s.optional(G.Schemable.number),
         },
         { extraProps: 'restParam', restParam: G.Schemable.boolean },
       )
@@ -333,16 +333,16 @@ describe('WithStructM', () => {
   describe('Eq', () => {
     it('should be true for the same object', () => {
       const eq = Eq.structM({
-        a: s.requiredProp(Eq_.number),
-        b: s.optionalProp(Eq_.string),
+        a: s.required(Eq_.number),
+        b: s.optional(Eq_.string),
       })
       const a = { a: 1, b: '2' }
       expect(eq.equals(a, a)).toBe(true)
     })
     it('should be true for two equal objects', () => {
       const eq = Eq.structM({
-        a: s.requiredProp(Eq_.number),
-        b: s.optionalProp(Eq_.string),
+        a: s.required(Eq_.number),
+        b: s.optional(Eq_.string),
       })
       const a = { a: 1, b: '2' }
       const b = { a: 1, b: '2' }
@@ -350,8 +350,8 @@ describe('WithStructM', () => {
     })
     it('should be false for two different objects', () => {
       const eq = Eq.structM({
-        a: s.requiredProp(Eq_.number),
-        b: s.optionalProp(Eq_.string),
+        a: s.required(Eq_.number),
+        b: s.optional(Eq_.string),
       })
       const a = { a: 1, b: '2' }
       const b = { a: 1, b: '3' }
@@ -360,8 +360,8 @@ describe('WithStructM', () => {
     it('should be true with rest params', () => {
       const eq = Eq.structM(
         {
-          a: s.requiredProp(Eq_.number),
-          b: s.optionalProp(Eq_.string),
+          a: s.required(Eq_.number),
+          b: s.optional(Eq_.string),
         },
         { extraProps: 'restParam', restParam: Eq_.array(Eq_.boolean) },
       )
@@ -372,8 +372,8 @@ describe('WithStructM', () => {
     it('should be false with rest params', () => {
       const eq = Eq.structM(
         {
-          a: s.requiredProp(Eq_.number),
-          b: s.optionalProp(Eq_.string),
+          a: s.required(Eq_.number),
+          b: s.optional(Eq_.string),
         },
         { extraProps: 'restParam', restParam: Eq_.array(Eq_.boolean) },
       )
@@ -384,8 +384,8 @@ describe('WithStructM', () => {
     it('fails fast for different number of keys', () => {
       const eq = Eq.structM(
         {
-          a: s.requiredProp(Eq_.number),
-          b: s.optionalProp(Eq_.string),
+          a: s.required(Eq_.number),
+          b: s.optional(Eq_.string),
         },
         { extraProps: 'restParam', restParam: Eq_.nullable(Eq_.boolean) },
       )
@@ -396,8 +396,8 @@ describe('WithStructM', () => {
     it('fails fast for xKey not in y', () => {
       const eq = Eq.structM(
         {
-          a: s.requiredProp(Eq_.number),
-          b: s.optionalProp(Eq_.string),
+          a: s.required(Eq_.number),
+          b: s.optional(Eq_.string),
         },
         { extraProps: 'restParam', restParam: Eq_.nullable(Eq_.boolean) },
       )
@@ -409,17 +409,17 @@ describe('WithStructM', () => {
   describe('Encoder', () => {
     it('encodes a struct with required and optional properites', () => {
       const encoder = Encoder.structM({
-        a: s.requiredProp(Enc.Schemable.string),
-        b: s.optionalProp(Enc.Schemable.number),
+        a: s.required(Enc.Schemable.string),
+        b: s.optional(Enc.Schemable.number),
       })
       expect(encoder.encode({ a: 'a' })).toEqual({ a: 'a' })
       expect(encoder.encode({ a: 'a', b: 1 })).toEqual({ a: 'a', b: 1 })
     })
     it('encodes with a custom key remap', () => {
       const encoder = Encoder.structM({
-        a: s.requiredProp(Enc.Schemable.string),
-        b: s.optionalProp(Enc.Schemable.number),
-        c: pipe(s.requiredProp(Enc.Schemable.string), s.mapKeyTo('d')),
+        a: s.required(Enc.Schemable.string),
+        b: s.optional(Enc.Schemable.number),
+        c: pipe(s.required(Enc.Schemable.string), s.mapKeyTo('d')),
       })
       expect(encoder.encode({ a: 'a', d: 'used-to-be-c' })).toEqual({
         a: 'a',
@@ -429,9 +429,9 @@ describe('WithStructM', () => {
     it('encodes with a custom key remap and a rest param', () => {
       const encoder = Encoder.structM(
         {
-          a: s.requiredProp(Enc.Schemable.string),
-          b: s.optionalProp(Enc.Schemable.number),
-          c: pipe(s.requiredProp(Enc.Schemable.string), s.mapKeyTo('d')),
+          a: s.required(Enc.Schemable.string),
+          b: s.optional(Enc.Schemable.number),
+          c: pipe(s.required(Enc.Schemable.string), s.mapKeyTo('d')),
         },
         {
           extraProps: 'restParam',
@@ -458,15 +458,15 @@ describe('WithStructM', () => {
     })
     it('strips additional props', () => {
       const encoder = Encoder.structM({
-        a: s.requiredProp(Enc.Schemable.string),
-        b: s.optionalProp(Enc.Schemable.number),
-        c: pipe(s.requiredProp(Enc.Schemable.string), s.mapKeyTo('d')),
+        a: s.required(Enc.Schemable.string),
+        b: s.optional(Enc.Schemable.number),
+        c: pipe(s.required(Enc.Schemable.string), s.mapKeyTo('d')),
       })
       const encoder2 = Encoder.structM(
         {
-          a: s.requiredProp(Enc.Schemable.string),
-          b: s.optionalProp(Enc.Schemable.number),
-          c: pipe(s.requiredProp(Enc.Schemable.string), s.mapKeyTo('d')),
+          a: s.required(Enc.Schemable.string),
+          b: s.optional(Enc.Schemable.number),
+          c: pipe(s.required(Enc.Schemable.string), s.mapKeyTo('d')),
         },
         { extraProps: 'error' },
       )
@@ -493,16 +493,16 @@ describe('WithStructM', () => {
     })
     it("behaves in a good way when there's an intersection", () => {
       const encoder = Encoder.structM({
-        a: pipe(s.requiredProp(Enc.Schemable.number), s.mapKeyTo('c')),
-        b: s.optionalProp(Enc.Schemable.number),
-        c: s.requiredProp(Enc.Schemable.string),
+        a: pipe(s.required(Enc.Schemable.number), s.mapKeyTo('c')),
+        b: s.optional(Enc.Schemable.number),
+        c: s.required(Enc.Schemable.string),
       })
       expect(encoder.encode({ b: 1, c: 5 })).toEqual({ b: 1, c: 5 })
     })
     it('ignores inherited properties', () => {
       const encoder = Encoder.structM({
-        a: s.requiredProp(Enc.Schemable.string),
-        b: s.optionalProp(Enc.Schemable.number),
+        a: s.required(Enc.Schemable.string),
+        b: s.optional(Enc.Schemable.number),
         __proto__: {
           test: 'foo',
         } as any,
@@ -515,15 +515,15 @@ describe('WithStructM', () => {
   })
   describe('TaskDecoder', () => {
     const decoder = TaskDecoder.structM({
-      a: s.requiredProp(TD.string),
-      b: s.optionalProp(TD.number),
+      a: s.required(TD.string),
+      b: s.optional(TD.number),
     })
     // Here we're only taking the first union element if there is an intersection
     it("behaves as expected when there's an intersection", async () => {
       const decoder = TaskDecoder.structM({
-        a: pipe(s.requiredProp(TD.number), s.mapKeyTo('c')),
-        b: s.optionalProp(TD.number),
-        c: s.requiredProp(TD.string),
+        a: pipe(s.required(TD.number), s.mapKeyTo('c')),
+        b: s.optional(TD.number),
+        c: s.required(TD.string),
       })
       expect(await decoder.decode({ a: 1, b: 1, c: 'c' })()).toEqual({
         _tag: 'Right',
@@ -565,9 +565,9 @@ describe('WithStructM', () => {
     })
     it('decodes with a custom key remap', async () => {
       const decoder = TaskDecoder.structM({
-        a: s.requiredProp(TD.string),
-        b: s.optionalProp(TD.number),
-        c: pipe(s.requiredProp(TD.string), s.mapKeyTo('d')),
+        a: s.required(TD.string),
+        b: s.optional(TD.number),
+        c: pipe(s.required(TD.string), s.mapKeyTo('d')),
       })
       expect(await decoder.decode({ a: 'a', c: 'used-to-be-c' })()).toEqual({
         _tag: 'Right',
@@ -577,9 +577,9 @@ describe('WithStructM', () => {
     it('decodes with a custom key remap and a rest param', async () => {
       const decoder = TaskDecoder.structM(
         {
-          a: s.requiredProp(TD.string),
-          b: s.optionalProp(TD.number),
-          c: pipe(s.requiredProp(TD.string), s.mapKeyTo('d')),
+          a: s.required(TD.string),
+          b: s.optional(TD.number),
+          c: pipe(s.required(TD.string), s.mapKeyTo('d')),
         },
         { extraProps: 'restParam', restParam: TD.array(TD.boolean) },
       )
@@ -607,9 +607,9 @@ describe('WithStructM', () => {
     it('fails with invalid rest param', async () => {
       const decoder = TaskDecoder.structM(
         {
-          a: s.requiredProp(TD.string),
-          b: s.optionalProp(TD.number),
-          c: pipe(s.requiredProp(TD.string), s.mapKeyTo('d')),
+          a: s.required(TD.string),
+          b: s.optional(TD.number),
+          c: pipe(s.required(TD.string), s.mapKeyTo('d')),
         },
         { extraProps: 'restParam', restParam: TD.array(TD.boolean) },
       )
@@ -630,9 +630,9 @@ describe('WithStructM', () => {
     it("doesn't fail without rest elements", async () => {
       const decoder = TaskDecoder.structM(
         {
-          a: s.requiredProp(TD.string),
-          b: s.optionalProp(TD.number),
-          c: pipe(s.requiredProp(TD.string), s.mapKeyTo('d')),
+          a: s.required(TD.string),
+          b: s.optional(TD.number),
+          c: pipe(s.required(TD.string), s.mapKeyTo('d')),
         },
         { extraProps: 'restParam', restParam: TD.array(TD.boolean) },
       )
@@ -644,9 +644,9 @@ describe('WithStructM', () => {
     it('fails on additional props', async () => {
       const decoder = TaskDecoder.structM(
         {
-          a: s.requiredProp(TD.string),
-          b: s.optionalProp(TD.number),
-          c: pipe(s.requiredProp(TD.string), s.mapKeyTo('d')),
+          a: s.required(TD.string),
+          b: s.optional(TD.number),
+          c: pipe(s.required(TD.string), s.mapKeyTo('d')),
         },
         { extraProps: 'error' },
       )
@@ -669,9 +669,9 @@ describe('WithStructM', () => {
     it('acts like strip if restParam is undefined', async () => {
       const decoder = TaskDecoder.structM(
         {
-          a: s.requiredProp(TD.string),
-          b: s.optionalProp(TD.number),
-          c: pipe(s.requiredProp(TD.string), s.mapKeyTo('d')),
+          a: s.required(TD.string),
+          b: s.optional(TD.number),
+          c: pipe(s.required(TD.string), s.mapKeyTo('d')),
         },
         { extraProps: 'restParam', restParam: undefined },
       )
@@ -689,15 +689,15 @@ describe('WithStructM', () => {
   })
   describe('Decoder', () => {
     const decoder = Decoder.structM({
-      a: s.requiredProp(D.string),
-      b: s.optionalProp(D.number),
+      a: s.required(D.string),
+      b: s.optional(D.number),
     })
     // Here we're only taking the first union element if there is an intersection
     it("behaves as expected when there's an intersection", () => {
       const decoder = Decoder.structM({
-        a: pipe(s.requiredProp(D.number), s.mapKeyTo('c')),
-        b: s.optionalProp(D.number),
-        c: s.requiredProp(D.string),
+        a: pipe(s.required(D.number), s.mapKeyTo('c')),
+        b: s.optional(D.number),
+        c: s.required(D.string),
       })
       expect(decoder.decode({ a: 1, b: 1, c: 'c' })).toEqual({
         _tag: 'Right',
@@ -736,9 +736,9 @@ describe('WithStructM', () => {
     })
     it('decodes with a custom key remap', () => {
       const decoder = Decoder.structM({
-        a: s.requiredProp(D.string),
-        b: s.optionalProp(D.number),
-        c: pipe(s.requiredProp(D.string), s.mapKeyTo('d')),
+        a: s.required(D.string),
+        b: s.optional(D.number),
+        c: pipe(s.required(D.string), s.mapKeyTo('d')),
       })
       expect(decoder.decode({ a: 'a', c: 'used-to-be-c' })).toEqual({
         _tag: 'Right',
@@ -748,9 +748,9 @@ describe('WithStructM', () => {
     it('decodes with a custom key remap and a rest param', () => {
       const decoder = Decoder.structM(
         {
-          a: s.requiredProp(D.string),
-          b: s.optionalProp(D.number),
-          c: pipe(s.requiredProp(D.string), s.mapKeyTo('d')),
+          a: s.required(D.string),
+          b: s.optional(D.number),
+          c: pipe(s.required(D.string), s.mapKeyTo('d')),
         },
         { extraProps: 'restParam', restParam: D.array(D.boolean) },
       )
@@ -778,9 +778,9 @@ describe('WithStructM', () => {
     it('fails with invalid rest param', () => {
       const decoder = Decoder.structM(
         {
-          a: s.requiredProp(D.string),
-          b: s.optionalProp(D.number),
-          c: pipe(s.requiredProp(D.string), s.mapKeyTo('d')),
+          a: s.required(D.string),
+          b: s.optional(D.number),
+          c: pipe(s.required(D.string), s.mapKeyTo('d')),
         },
         { extraProps: 'restParam', restParam: D.array(D.boolean) },
       )
@@ -801,9 +801,9 @@ describe('WithStructM', () => {
     it("doesn't fail without rest elements", () => {
       const decoder = Decoder.structM(
         {
-          a: s.requiredProp(D.string),
-          b: s.optionalProp(D.number),
-          c: pipe(s.requiredProp(D.string), s.mapKeyTo('d')),
+          a: s.required(D.string),
+          b: s.optional(D.number),
+          c: pipe(s.required(D.string), s.mapKeyTo('d')),
         },
         { extraProps: 'restParam', restParam: D.array(D.boolean) },
       )
@@ -815,9 +815,9 @@ describe('WithStructM', () => {
     it('fails on additional props', () => {
       const decoder = Decoder.structM(
         {
-          a: s.requiredProp(D.string),
-          b: s.optionalProp(D.number),
-          c: pipe(s.requiredProp(D.string), s.mapKeyTo('d')),
+          a: s.required(D.string),
+          b: s.optional(D.number),
+          c: pipe(s.required(D.string), s.mapKeyTo('d')),
         },
         { extraProps: 'error' },
       )
@@ -840,9 +840,9 @@ describe('WithStructM', () => {
     it('acts like strip if restParam is undefined', () => {
       const decoder = Decoder.structM(
         {
-          a: s.requiredProp(D.string),
-          b: s.optionalProp(D.number),
-          c: pipe(s.requiredProp(D.string), s.mapKeyTo('d')),
+          a: s.required(D.string),
+          b: s.optional(D.number),
+          c: pipe(s.required(D.string), s.mapKeyTo('d')),
         },
         { extraProps: 'restParam', restParam: undefined },
       )
@@ -860,7 +860,7 @@ describe('WithStructM', () => {
     describe("Ethan's weird edge cases", () => {
       const decoder = Decoder.structM(
         {
-          date: s.optionalProp(decodeOptionFromNullableDateFromUnix),
+          date: s.optional(decodeOptionFromNullableDateFromUnix),
         },
         { extraProps: 'restParam', restParam: decodeOptionFromNullableString },
       )
@@ -916,15 +916,15 @@ describe('WithStructM', () => {
   describe('Arbitrary', () => {
     it('generates valid values', () => {
       const arbitrary = Arbitrary.structM({
-        a: s.requiredProp(Arb.string),
-        b: s.optionalProp(Arb.number),
-        c: pipe(s.requiredProp(Arb.string), s.mapKeyTo('d')),
+        a: s.required(Arb.string),
+        b: s.optional(Arb.number),
+        c: pipe(s.required(Arb.string), s.mapKeyTo('d')),
         __proto__: { e: 'f' } as any,
       })
       const guard = Guard.structM({
-        a: s.requiredProp(G.string),
-        b: s.optionalProp(G.number),
-        c: pipe(s.requiredProp(G.string), s.mapKeyTo('d')),
+        a: s.required(G.string),
+        b: s.optional(G.number),
+        c: pipe(s.required(G.string), s.mapKeyTo('d')),
         __proto__: { e: 'f' } as any,
       })
       fc.assert(
@@ -936,17 +936,17 @@ describe('WithStructM', () => {
     it('generates rest params', () => {
       const arbitrary = Arbitrary.structM(
         {
-          a: s.requiredProp(Arb.string),
-          b: s.optionalProp(Arb.number),
-          c: pipe(s.requiredProp(Arb.string), s.mapKeyTo('d')),
+          a: s.required(Arb.string),
+          b: s.optional(Arb.number),
+          c: pipe(s.required(Arb.string), s.mapKeyTo('d')),
         },
         { extraProps: 'restParam', restParam: Arb.array(Arb.boolean) },
       )
       const guard = Guard.structM(
         {
-          a: s.requiredProp(G.string),
-          b: s.optionalProp(G.number),
-          c: pipe(s.requiredProp(G.string), s.mapKeyTo('d')),
+          a: s.required(G.string),
+          b: s.optional(G.number),
+          c: pipe(s.required(G.string), s.mapKeyTo('d')),
         },
         { extraProps: 'restParam', restParam: G.array(G.boolean) },
       )
@@ -959,15 +959,15 @@ describe('WithStructM', () => {
   })
   describe('Type', () => {
     const decoder = Type.structM({
-      a: s.requiredProp(t.string),
-      b: s.optionalProp(t.number),
+      a: s.required(t.string),
+      b: s.optional(t.number),
     })
     // Here we're only taking the first union element if there is an intersection
     it("behaves as expected when there's an intersection", () => {
       const decoder = Type.structM({
-        a: pipe(s.requiredProp(t.number), s.mapKeyTo('c')),
-        b: s.optionalProp(t.number),
-        c: s.requiredProp(t.string),
+        a: pipe(s.required(t.number), s.mapKeyTo('c')),
+        b: s.optional(t.number),
+        c: s.required(t.string),
       })
       expect(decoder.decode({ a: 1, b: 1, c: 'c' })).toEqual({
         _tag: 'Right',
@@ -1010,9 +1010,9 @@ describe('WithStructM', () => {
     })
     it('decodes with a custom key remap', () => {
       const decoder = Decoder.structM({
-        a: s.requiredProp(D.string),
-        b: s.optionalProp(D.number),
-        c: pipe(s.requiredProp(D.string), s.mapKeyTo('d')),
+        a: s.required(D.string),
+        b: s.optional(D.number),
+        c: pipe(s.required(D.string), s.mapKeyTo('d')),
       })
       expect(decoder.decode({ a: 'a', c: 'used-to-be-c' })).toEqual({
         _tag: 'Right',
@@ -1022,9 +1022,9 @@ describe('WithStructM', () => {
     it('decodes with a custom key remap and a rest param', () => {
       const decoder = Decoder.structM(
         {
-          a: s.requiredProp(D.string),
-          b: s.optionalProp(D.number),
-          c: pipe(s.requiredProp(D.string), s.mapKeyTo('d')),
+          a: s.required(D.string),
+          b: s.optional(D.number),
+          c: pipe(s.required(D.string), s.mapKeyTo('d')),
         },
         { extraProps: 'restParam', restParam: D.array(D.boolean) },
       )
@@ -1052,9 +1052,9 @@ describe('WithStructM', () => {
     it('fails with invalid rest param', () => {
       const decoder = Type.structM(
         {
-          a: s.requiredProp(t.string),
-          b: s.optionalProp(t.number),
-          c: pipe(s.requiredProp(t.string), s.mapKeyTo('d')),
+          a: s.required(t.string),
+          b: s.optional(t.number),
+          c: pipe(s.required(t.string), s.mapKeyTo('d')),
         },
         { extraProps: 'restParam', restParam: t.array(t.boolean) },
       )
@@ -1079,9 +1079,9 @@ describe('WithStructM', () => {
     it("doesn't fail without rest elements", () => {
       const decoder = Type.structM(
         {
-          a: s.requiredProp(t.string),
-          b: s.optionalProp(t.number),
-          c: pipe(s.requiredProp(t.string), s.mapKeyTo('d')),
+          a: s.required(t.string),
+          b: s.optional(t.number),
+          c: pipe(s.required(t.string), s.mapKeyTo('d')),
         },
         { extraProps: 'restParam', restParam: t.array(t.boolean) },
       )
@@ -1093,9 +1093,9 @@ describe('WithStructM', () => {
     it('fails on additional props', () => {
       const decoder = Type.structM(
         {
-          a: s.requiredProp(t.string),
-          b: s.optionalProp(t.number),
-          c: pipe(s.requiredProp(t.string), s.mapKeyTo('d')),
+          a: s.required(t.string),
+          b: s.optional(t.number),
+          c: pipe(s.required(t.string), s.mapKeyTo('d')),
         },
         { extraProps: 'error' },
       )
@@ -1115,9 +1115,9 @@ describe('WithStructM', () => {
     it('acts like strip if restParam is undefined', () => {
       const decoder = Type.structM(
         {
-          a: s.requiredProp(t.string),
-          b: s.optionalProp(t.number),
-          c: pipe(s.requiredProp(t.string), s.mapKeyTo('d')),
+          a: s.required(t.string),
+          b: s.optional(t.number),
+          c: pipe(s.required(t.string), s.mapKeyTo('d')),
         },
         { extraProps: 'restParam', restParam: undefined },
       )

--- a/tests/struct.test.ts
+++ b/tests/struct.test.ts
@@ -1,0 +1,182 @@
+import { expectTypeOf } from 'expect-type'
+import * as fc from 'fast-check'
+import { pipe } from 'fp-ts/function'
+import * as D from 'io-ts/Decoder'
+import * as Enc from 'io-ts/Encoder'
+import * as G from 'io-ts/Guard'
+import { getArbitrary } from 'schemata-ts/Arbitrary'
+import { getDecoder } from 'schemata-ts/Decoder'
+import { getEncoder } from 'schemata-ts/Encoder'
+import { getGuard } from 'schemata-ts/Guard'
+
+import * as S from '../src/schemata'
+import * as s from '../src/struct'
+
+const testStruct = s.defineStruct({
+  a: s.required(S.String),
+  b: s.optional(S.Number),
+  c: s.mapKeyTo('e')(s.required(S.Boolean)),
+  d: s.mapKeyTo('f')(s.optional(S.Unknown)),
+})
+
+describe('type-level tests', () => {
+  describe('defineStruct', () => {
+    test('defineStruct2', () => {
+      const struct = getEncoder(S.StructM(testStruct))
+      expectTypeOf<typeof struct>().toEqualTypeOf<
+        Enc.Encoder<
+          { a: string; b?: number; c: boolean; d?: unknown },
+          { a: string; b?: number; e: boolean; f?: unknown }
+        >
+      >()
+    })
+    test('defineStruct2c', () => {
+      const struct = getDecoder(S.StructM(testStruct))
+      expectTypeOf<typeof struct>().toEqualTypeOf<
+        D.Decoder<unknown, { a: string; b?: number; e: boolean; f?: unknown }>
+      >()
+    })
+    test('defineStruct1', () => {
+      const struct = getGuard(S.StructM(testStruct))
+      expectTypeOf<typeof struct>().toEqualTypeOf<
+        G.Guard<unknown, { a: string; b?: number; e: boolean; f?: unknown }>
+      >()
+    })
+  })
+  describe('partial', () => {
+    test('partial2', () => {
+      const partial = getEncoder(S.StructM(s.partial(testStruct)))
+      expectTypeOf<typeof partial>().toEqualTypeOf<
+        Enc.Encoder<
+          { a?: string; b?: number; c?: boolean; d?: unknown },
+          { a?: string; b?: number; e?: boolean; f?: unknown }
+        >
+      >()
+    })
+    test('partial2c', () => {
+      const partial = getDecoder(S.StructM(s.partial(testStruct)))
+      expectTypeOf<typeof partial>().toEqualTypeOf<
+        D.Decoder<unknown, { a?: string; b?: number; e?: boolean; f?: unknown }>
+      >()
+    })
+    test('partial1', () => {
+      const partial = getGuard(S.StructM(s.partial(testStruct)))
+      expectTypeOf<typeof partial>().toEqualTypeOf<
+        G.Guard<unknown, { a?: string; b?: number; e?: boolean; f?: unknown }>
+      >()
+    })
+  })
+  describe('complete', () => {
+    test('complete2', () => {
+      const required = getEncoder(S.StructM(s.complete(testStruct)))
+      expectTypeOf<typeof required>().toEqualTypeOf<
+        Enc.Encoder<
+          { a: string; b: number; c: boolean; d: unknown },
+          { a: string; b: number; e: boolean; f: unknown }
+        >
+      >()
+    })
+    test('complete2c', () => {
+      const complete = getDecoder(S.StructM(s.complete(testStruct)))
+      expectTypeOf<typeof complete>().toEqualTypeOf<
+        D.Decoder<unknown, { a: string; b: number; e: boolean; f: unknown }>
+      >()
+    })
+    test('complete1', () => {
+      const complete = getGuard(S.StructM(s.complete(testStruct)))
+      expectTypeOf<typeof complete>().toEqualTypeOf<
+        G.Guard<unknown, { a: string; b: number; e: boolean; f: unknown }>
+      >()
+    })
+  })
+  test('pick', () => {
+    const pick = getEncoder(S.StructM(pipe(testStruct, s.pick('a', 'd'))))
+    expectTypeOf<typeof pick>().toEqualTypeOf<
+      Enc.Encoder<{ a: string; d?: unknown }, { a: string; f?: unknown }>
+    >()
+  })
+  test('omit', () => {
+    const omit = getEncoder(S.StructM(pipe(testStruct, s.omit('a', 'd'))))
+    expectTypeOf<typeof omit>().toEqualTypeOf<
+      Enc.Encoder<{ b?: number; c: boolean }, { b?: number; e: boolean }>
+    >()
+  })
+})
+
+describe('value-level tests', () => {
+  describe('partial', () => {
+    test('encoder', () => {
+      const partial = getEncoder(S.StructM(s.partial(testStruct)))
+      expect(partial.encode({})).toEqual({})
+      expect(partial.encode({ a: 'a' })).toEqual({ a: 'a' })
+      expect(partial.encode({ a: 'a', b: 1 })).toEqual({ a: 'a', b: 1 })
+      expect(partial.encode({ a: 'a', b: 1, e: true })).toEqual({ a: 'a', b: 1, c: true })
+    })
+    test('decoder', () => {
+      const partial = getDecoder(S.StructM(s.partial(testStruct)))
+      expect(partial.decode({})).toEqual(D.success({}))
+      expect(partial.decode({ a: 'a' })).toEqual(D.success({ a: 'a' }))
+      expect(partial.decode({ a: 'a', b: 1 })).toEqual(D.success({ a: 'a', b: 1 }))
+      expect(partial.decode({ a: 'a', b: 1, c: true })).toEqual(
+        D.success({ a: 'a', b: 1, e: true }),
+      )
+    })
+    test('arb / guard', () => {
+      const g = getGuard(S.StructM(s.partial(testStruct)))
+      const arb = getArbitrary(S.StructM(s.partial(testStruct)))
+      fc.assert(fc.property(arb.arbitrary(fc), g.is))
+    })
+  })
+  describe('complete', () => {
+    test('encoder', () => {
+      const partial = getEncoder(S.StructM(s.complete(testStruct)))
+      expect(partial.encode({ a: 'a', b: 1, e: true, f: null })).toEqual({
+        a: 'a',
+        b: 1,
+        c: true,
+        d: null,
+      })
+    })
+    test('decoder', () => {
+      const partial = getDecoder(S.StructM(s.complete(testStruct)))
+      expect(partial.decode({ a: 'a', b: 1, c: true, d: '' })).toEqual(
+        D.success({ a: 'a', b: 1, e: true, f: '' }),
+      )
+    })
+    test('arb / guard', () => {
+      const g = getGuard(S.StructM(s.complete(testStruct)))
+      const arb = getArbitrary(S.StructM(s.complete(testStruct)))
+      fc.assert(fc.property(arb.arbitrary(fc), g.is))
+    })
+  })
+  describe('pick', () => {
+    test('encoder', () => {
+      const pick = getEncoder(S.StructM(pipe(testStruct, s.pick('a', 'd'))))
+      expect(pick.encode({ a: 'a', f: null })).toEqual({ a: 'a', d: null })
+    })
+    test('decoder', () => {
+      const pick = getDecoder(S.StructM(pipe(testStruct, s.pick('a', 'd'))))
+      expect(pick.decode({ a: 'a', d: null })).toEqual(D.success({ a: 'a', f: null }))
+    })
+    test('arb / guard', () => {
+      const g = getGuard(S.StructM(pipe(testStruct, s.pick('a', 'd'))))
+      const arb = getArbitrary(S.StructM(pipe(testStruct, s.pick('a', 'd'))))
+      fc.assert(fc.property(arb.arbitrary(fc), g.is))
+    })
+  })
+  describe('omit', () => {
+    test('encoder', () => {
+      const omit = getEncoder(S.StructM(pipe(testStruct, s.omit('a', 'd'))))
+      expect(omit.encode({ b: 1, e: true })).toEqual({ b: 1, c: true })
+    })
+    test('decoder', () => {
+      const omit = getDecoder(S.StructM(pipe(testStruct, s.omit('a', 'd'))))
+      expect(omit.decode({ b: 1, c: true })).toEqual(D.success({ b: 1, e: true }))
+    })
+    test('arb / guard', () => {
+      const g = getGuard(S.StructM(pipe(testStruct, s.omit('a', 'd'))))
+      const arb = getArbitrary(S.StructM(pipe(testStruct, s.omit('a', 'd'))))
+      fc.assert(fc.property(arb.arbitrary(fc), g.is))
+    })
+  })
+})


### PR DESCRIPTION
This adjusts the API of StructM, and adds a `struct` module for constructing reusable struct definitions with helper functions, like `partial`, `complete`, `pick`, and `omit`.

Closes #246 