### PR TITLE
[#255] Add `mapKeysWith` and `camelCaseKeys`

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ assert.equal(PB.regexFromPattern(usPhoneNumber).test('1234567890'), false)
 | BigIntFromString      | Conversion     |
 | BooleanFromString     | Conversion     |
 | BooleanFromNumber     | Conversion     |
+| CamelCaseFromMixed    | Conversion     |
 | DateFromInt           | Conversion     |
 | DateFromIsoString     | Conversion     |
 | DateFromUnixTime      | Conversion     |
@@ -280,13 +281,3 @@ assert.equal(PB.regexFromPattern(usPhoneNumber).test('1234567890'), false)
 | UUID                  | String         |
 
 Additionally, there are more unlisted base schemable schemata also exported from `schemata-ts/schemata`. These can be used to construct more complex schemata. There are many examples of custom schemata in `src/schemata` to use as a reference.
-
-## Future Features
-
-schemata-ts is planned to support the following features in various 1.x and 2.x versions in the near future:
-
-- ~~JsonSerializer and JsonDeserializer: encoding / decoding from Json strings~~ Added in 1.1.0
-- ~~Json Schema: generating JSON-Schema from schemata ([#137](https://github.com/jacob-alford/schemata-ts/issues/137))~~ Added in 1.2.0
-- ~~Mapped Structs: conversions between struct types, i.e. `snake-case` keys to `camelCase` keys~~ Added in 1.3.0
-- More generic schemata: (~~SetFromArray~~ Added in 1.3.0, ~~NonEmptyArray~~ Added in 1.1.0)
-- More validator.js branded schemata

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "change-case": "^4.1.2",
     "type-fest": "^3.5.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -112,5 +112,9 @@
     "ts-jest": "^26.5.3",
     "ts-node": "^10.8.1",
     "typescript": "^4.2.3"
+  },
+  "dependencies": {
+    "change-case": "^4.1.2",
+    "type-fest": "^3.5.7"
   }
 }

--- a/src/base/ArbitraryBase.ts
+++ b/src/base/ArbitraryBase.ts
@@ -161,7 +161,11 @@ export const partial = <A>(properties: { [K in keyof A]: Arbitrary<A[K]> }): Arb
  * @category Combinators
  */
 export const record = <A>(codomain: Arbitrary<A>): Arbitrary<Record<string, A>> => ({
-  arbitrary: fc => fc.dictionary(string.arbitrary(fc), codomain.arbitrary(fc)),
+  arbitrary: fc =>
+    fc.dictionary(
+      string.arbitrary(fc).filter(s => s !== '__proto__'),
+      codomain.arbitrary(fc),
+    ),
 })
 
 /**

--- a/src/base/SchemaBase.ts
+++ b/src/base/SchemaBase.ts
@@ -63,6 +63,31 @@ export const Nullable: S2.Schemable2<URI>['nullable'] = or =>
 /**
  * @since 1.0.0
  * @category Combinators
+ * @example
+ *   import * as E from 'fp-ts/Either'
+ *   import * as S from 'schemata-ts/schemata'
+ *   import { getDecoder } from 'schemata-ts/Decoder'
+ *
+ *   const SomeDomainType = S.Struct({
+ *     a: S.String,
+ *     b: S.BooleanFromNumber,
+ *   })
+ *
+ *   // SomeDomainType will have the type:
+ *   // SchemaExt<{ a: string, b: number }, { a: string, b: boolean }>
+ *
+ *   const decoder = getDecoder(SomeDomainType)
+ *
+ *   assert.deepStrictEqual(
+ *     decoder.decode({
+ *       a: 'foo',
+ *       b: 0,
+ *     }),
+ *     E.right({
+ *       a: 'foo',
+ *       b: false,
+ *     }),
+ *   )
  */
 export const Struct: S2.Schemable2<URI>['struct'] = props =>
   SC.make(_ => {

--- a/src/internal/camelcase.ts
+++ b/src/internal/camelcase.ts
@@ -11,7 +11,7 @@ import * as Pred from 'fp-ts/Predicate'
 import * as RA from 'fp-ts/ReadonlyArray'
 import * as Str from 'fp-ts/string'
 import * as PB from 'schemata-ts/PatternBuilder'
-import { type CamelCase } from 'type-fest'
+import type { CamelCase } from 'type-fest'
 
 /** Convert a character code to character */
 const cc: (code: number) => string = String.fromCharCode

--- a/src/internal/camelcase.ts
+++ b/src/internal/camelcase.ts
@@ -1,0 +1,184 @@
+/**
+ * Parses a string and turns it into camelCase.
+ *
+ * @since 1.4.0
+ */
+import { tailRec } from 'fp-ts/ChainRec'
+import * as E from 'fp-ts/Either'
+import { flow, identity, pipe } from 'fp-ts/function'
+import * as O from 'fp-ts/Option'
+import * as Pred from 'fp-ts/Predicate'
+import * as RA from 'fp-ts/ReadonlyArray'
+import * as Str from 'fp-ts/string'
+import * as PB from 'schemata-ts/PatternBuilder'
+import { type CamelCase } from 'type-fest'
+
+/** Convert a character code to character */
+const cc: (code: number) => string = String.fromCharCode
+
+/** A list of whitespace + "-" + "_" patterns to match type-fest's type-level camelcase */
+const delimiters = PB.characterClass(
+  false,
+  cc(9), // tab
+  cc(10), // line feed
+  cc(11), // vertical tab
+  cc(12), // form feed
+  cc(13), // carriage return
+  cc(32), // space
+  cc(133), // next line
+  cc(160), // non-breaking space
+  cc(5760), // ogham space mark
+  cc(8192), // en quad
+  cc(8193), // em quad
+  cc(8194), // en space
+  cc(8195), // em space
+  cc(8196), // three-per-em space
+  cc(8197), // four-per-em space
+  cc(8198), // six-per-em space
+  cc(8199), // figure space
+  cc(8200), // punctuation space
+  cc(8201), // thin space
+  cc(8202), // hair space
+  cc(8232), // line separator
+  cc(8233), // paragraph separator
+  cc(8239), // narrow no-break space
+  cc(8287), // medium mathematical space
+  cc(12288), // ideographic space
+  cc(65279), // zero width no-break space
+  '-', // hyphen-minus
+  '_', // low line
+)
+
+const delimiterRegex = PB.regexFromPattern(delimiters)
+
+const dropRightWhile: (
+  predicate: (a: string) => boolean,
+) => (as: ReadonlyArray<string>) => ReadonlyArray<string> = predicate => as =>
+  pipe(
+    as,
+    RA.findLastIndex(Pred.not(predicate)),
+    O.fold(
+      () => [],
+      i => as.slice(0, i + 1),
+    ),
+  )
+
+const trimDelimiters: (s: string) => string = flow(
+  Str.trim,
+  Str.split(''),
+  RA.dropLeftWhile(s => delimiterRegex.test(s)),
+  dropRightWhile(s => delimiterRegex.test(s)),
+  RA.foldMap(Str.Monoid)(identity),
+)
+
+const isUppercase = (s: string): boolean => s === s.toUpperCase()
+const isNumber = (char: string): boolean => /[0-9]/.test(char)
+const hasLowercase = (s: string): boolean => /[a-z]/gm.test(s)
+
+type Stream = {
+  readonly input: string
+  readonly output: string
+  readonly index: number
+  readonly lastCharWasDelimiter: boolean
+  readonly lastCharWasNumber: boolean
+  readonly hasBeenScreaming: boolean
+}
+
+/**
+ * Parses a string and turns it into camelCase.
+ *
+ * @since 1.4.0
+ */
+export const camelCase = <S extends string>(
+  input: S,
+): CamelCase<S, { preserveConsecutiveUppercase: true }> => {
+  if (input.length === 0) return input as any
+
+  const go: (s: Stream) => E.Either<Stream, string> = s => {
+    const char = s.input.charAt(s.index)
+    const nextChar = pipe(
+      s.input.charAt(s.index + 1),
+      O.fromPredicate(s => s.length > 0),
+    )
+
+    // Stream is exhausted
+    if (char === '') {
+      return E.right(s.output)
+    }
+
+    // Lowercase the first char
+    if (s.index === 0) {
+      return E.left({
+        input: s.input,
+        output: s.output + char.toLowerCase(),
+        index: s.index + 1,
+        lastCharWasDelimiter: false,
+        lastCharWasNumber: isNumber(char),
+        hasBeenScreaming: isUppercase(char),
+      })
+    }
+
+    // If the character is a delimiter, skip it
+    if (delimiterRegex.test(char)) {
+      return E.left({
+        input: s.input,
+        output: s.output,
+        index: s.index + 1,
+        lastCharWasDelimiter: true,
+        lastCharWasNumber: false,
+        hasBeenScreaming: false,
+      })
+    }
+
+    // If the last char was screaming, lowercase the current char if the next char is uppercase
+    if (s.hasBeenScreaming && isUppercase(char)) {
+      return E.left({
+        input: s.input,
+        output:
+          s.output +
+          (O.isSome(nextChar) && isUppercase(nextChar.value) ? char.toLowerCase() : char),
+        index: s.index + 1,
+        lastCharWasDelimiter: false,
+        lastCharWasNumber: isNumber(char),
+        hasBeenScreaming: true,
+      })
+    }
+
+    // If the last char was a delimiter (or number), uppercase the current char
+    if (s.lastCharWasDelimiter || s.lastCharWasNumber) {
+      return E.left({
+        input: s.input,
+        output: s.output + char.toUpperCase(),
+        index: s.index + 1,
+        hasBeenScreaming: isUppercase(char),
+        lastCharWasNumber: isNumber(char),
+        lastCharWasDelimiter: false,
+      })
+    }
+
+    return E.left({
+      input: s.input,
+      output: s.output + char,
+      index: s.index + 1,
+      lastCharWasDelimiter: false,
+      lastCharWasNumber: isNumber(char),
+      hasBeenScreaming: isUppercase(char),
+    })
+  }
+
+  const trimmed = trimDelimiters(input)
+
+  if (trimmed.length === 0) return trimmed as any
+
+  return tailRec(
+    {
+      input: hasLowercase(trimmed) ? trimmed : trimmed.toLowerCase(),
+      output: '',
+      index: 0,
+      lastCharWasDelimiter: false,
+      lastCharWasNumber: false,
+      hasBeenScreaming: isUppercase(trimmed.charAt(0)),
+    },
+    go,
+  ) as any
+}

--- a/src/schemata.ts
+++ b/src/schemata.ts
@@ -224,6 +224,16 @@ export {
 
 export {
   /**
+   * The same as the `Struct` schema combinator, but keys are transformed to camel case in
+   * the output type.
+   *
+   * @since 1.4.0
+   * @category Model
+   */
+  CamelCaseFromMixed,
+} from 'schemata-ts/schemata/generic/CamelCaseFromMixed'
+export {
+  /**
    * A schema for wrapping an inner schema's output value in a newtype.
    *
    * @since 1.4.0

--- a/src/schemata/generic/CamelCaseFromMixed.ts
+++ b/src/schemata/generic/CamelCaseFromMixed.ts
@@ -1,0 +1,68 @@
+/**
+ * The same as the `Struct` schema combinator, but keys are transformed to camel case in
+ * the output type.
+ *
+ * @since 1.4.0
+ * @category Model
+ */
+import { InputOf, make, OutputOf, SchemaExt } from 'schemata-ts/SchemaExt'
+import * as s from 'schemata-ts/struct'
+import { CamelCase } from 'type-fest'
+
+/**
+ * @since 1.4.0
+ * @category Model
+ */
+export type CamelCaseFromMixedS = <T extends Record<string, SchemaExt<unknown, unknown>>>(
+  props: T,
+) => SchemaExt<
+  {
+    [K in keyof T]: InputOf<T[K]>
+  },
+  {
+    [K in keyof T as CamelCase<K, { preserveConsecutiveUppercase: true }>]: OutputOf<T[K]>
+  }
+>
+
+/**
+ * The same as the `Struct` schema combinator, but keys are transformed to camel case in
+ * the output type.
+ *
+ * @since 1.4.0
+ * @category Schema
+ * @example
+ *   import * as E from 'fp-ts/Either'
+ *   import * as S from 'schemata-ts/schemata'
+ *   import { getDecoder } from 'schemata-ts/Decoder'
+ *
+ *   const DatabasePerson = S.CamelCaseFromMixed({
+ *     first_name: S.String,
+ *     last_name: S.String,
+ *     age: S.Number,
+ *     is_married: S.Boolean,
+ *   })
+ *   const decodeDatabasePerson = getDecoder(DatabasePerson)
+ *   assert.deepStrictEqual(
+ *     decodeDatabasePerson.decode({
+ *       first_name: 'John',
+ *       last_name: 'Doe',
+ *       age: 42,
+ *       is_married: false,
+ *     }),
+ *     E.right({
+ *       firstName: 'John',
+ *       lastName: 'Doe',
+ *       age: 42,
+ *       isMarried: false,
+ *     }),
+ *   )
+ */
+export const CamelCaseFromMixed: CamelCaseFromMixedS = props =>
+  make(S => {
+    const props_ = {} as Record<string, unknown>
+    for (const k in props) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      props_[k] = s.required(props[k]!(S))
+    }
+    return S.structM(s.camelCaseKeys(props_ as any)) as any
+  })

--- a/src/schemata/generic/CamelCaseFromMixed.ts
+++ b/src/schemata/generic/CamelCaseFromMixed.ts
@@ -39,15 +39,23 @@ export type CamelCaseFromMixedS = <T extends Record<string, SchemaExt<unknown, u
  *     first_name: S.String,
  *     last_name: S.String,
  *     age: S.Number,
- *     is_married: S.Boolean,
+ *     is_married: S.BooleanFromString,
  *   })
- *   const decodeDatabasePerson = getDecoder(DatabasePerson)
+ *
+ *   // DatabasePerson will have the type:
+ *   // SchemaExt<
+ *   //   { first_name: string, last_name: string, age: number, is_married: string },
+ *   //   { firstName: string, lastName: string, age: number, isMarried: boolean }
+ *   // >
+ *
+ *   const decoder = getDecoder(DatabasePerson)
+ *
  *   assert.deepStrictEqual(
- *     decodeDatabasePerson.decode({
+ *     decoder.decode({
  *       first_name: 'John',
  *       last_name: 'Doe',
  *       age: 42,
- *       is_married: false,
+ *       is_married: 'false',
  *     }),
  *     E.right({
  *       firstName: 'John',

--- a/src/schemata/generic/CamelCaseFromMixed.ts
+++ b/src/schemata/generic/CamelCaseFromMixed.ts
@@ -7,7 +7,7 @@
  */
 import { InputOf, make, OutputOf, SchemaExt } from 'schemata-ts/SchemaExt'
 import * as s from 'schemata-ts/struct'
-import { CamelCase } from 'type-fest'
+import type { CamelCase } from 'type-fest'
 
 /**
  * @since 1.4.0

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -492,6 +492,59 @@ interface StructDefinition {
  */
 export const defineStruct: StructDefinition = identity
 
+interface Struct {
+  /**
+   * A convenience function to declare a struct where all keys are required
+   *
+   * @since 1.4.0
+   * @category Models
+   */
+  <S extends URIS2, Props extends Record<string, Kind2<S, any, any>>>(props: Props): {
+    [K in keyof Props]: Prop2<RequiredKeyFlag, S, Props[K], KeyNotMapped>
+  }
+  /**
+   * A convenience function to declare a struct where all keys are required
+   *
+   * @since 1.4.0
+   * @category Models
+   */
+  <S extends URIS, Props extends Record<string, Kind<S, any>>>(props: Props): {
+    [K in keyof Props]: Prop1<RequiredKeyFlag, S, Props[K], KeyNotMapped>
+  }
+  /**
+   * A convenience function to declare a struct where all keys are required
+   *
+   * @since 1.4.0
+   * @category Models
+   */
+  <S, Props extends Record<string, HKT2<S, any, any>>>(props: Props): {
+    [K in keyof Props]: Prop<RequiredKeyFlag, S, Props[K], KeyNotMapped>
+  }
+}
+
+/**
+ * Defines a StructM declaration where all keys are required
+ *
+ * @since 1.4.0
+ * @category Constructors
+ */
+export const struct: Struct = (props: Record<string, HKT2<unknown, any, any>>) => {
+  const remappedProps: Record<
+    string,
+    Prop<RequiredKeyFlag, unknown, HKT2<unknown, any, any>, KeyNotMapped>
+  > = {}
+  for (const key in props) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const prop = props[key]!
+    remappedProps[key] = {
+      _val: prop,
+      _keyRemap: KeyNotMapped,
+      _flag: RequiredKeyFlag,
+    }
+  }
+  return remappedProps
+}
+
 interface Partial {
   /**
    * Remap a StructM definition such that all keys are optional

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -3,9 +3,9 @@
  *
  * @since 1.3.0
  */
-import { camelCase } from 'change-case'
 import { identity } from 'fp-ts/function'
 import { HKT2, Kind, Kind2, URIS, URIS2 } from 'fp-ts/HKT'
+import { camelCase } from 'schemata-ts/internal/camelcase'
 import { CamelCase } from 'type-fest'
 
 /**
@@ -254,7 +254,7 @@ export const keyIsNotMapped = (key: string | KeyNotMapped): key is KeyNotMapped 
 /**
  * A type-level key remap provider
  *
- * @since 1.3.0
+ * @since 1.4.0
  * @category Models
  */
 export interface KeyRemapLambda {
@@ -265,7 +265,7 @@ export interface KeyRemapLambda {
 /**
  * Applies a remap type-level function to a remap lambda
  *
- * @since 1.3.0
+ * @since 1.4.0
  * @category Models
  */
 export type ApplyKeyRemap<R extends KeyRemapLambda, Val extends string> = R extends {
@@ -283,9 +283,11 @@ interface MapKeysWith {
   /**
    * Used to remap a struct's keys using a provided type-level function and equivalent string mapper
    *
-   * @since 1.3.0
+   * @since 1.4.0
    */
-  <R extends KeyRemapLambda>(mapping: (s: string) => string): <
+  <R extends KeyRemapLambda>(
+    mapping: <S extends string>(s: S) => ApplyKeyRemap<KeyRemapLambda, S>,
+  ): <
     S extends URIS2,
     Props extends Record<
       string,
@@ -303,9 +305,11 @@ interface MapKeysWith {
   /**
    * Used to remap a struct's keys using a provided type-level function and equivalent string mapper
    *
-   * @since 1.3.0
+   * @since 1.4.0
    */
-  <R extends KeyRemapLambda>(mapping: (s: string) => string): <
+  <R extends KeyRemapLambda>(
+    mapping: <S extends string>(s: S) => ApplyKeyRemap<KeyRemapLambda, S>,
+  ): <
     S extends URIS,
     Props extends Record<string, Prop1<KeyFlag, S, Kind<S, any>, string | KeyNotMapped>>,
   >(
@@ -320,9 +324,11 @@ interface MapKeysWith {
   /**
    * Used to remap a struct's keys using a provided type-level function and equivalent string mapper
    *
-   * @since 1.3.0
+   * @since 1.4.0
    */
-  <R extends KeyRemapLambda>(mapping: (s: string) => string): <
+  <R extends KeyRemapLambda>(
+    mapping: <S extends string>(s: S) => ApplyKeyRemap<KeyRemapLambda, S>,
+  ): <
     S,
     Props extends Record<
       string,
@@ -342,7 +348,7 @@ interface MapKeysWith {
 /**
  * Remap a struct's keys using provided RemapLambda, and string-mapping function
  *
- * @since 1.3.0
+ * @since 1.4.0
  * @category Combinators
  * @example
  *   import * as E from 'fp-ts/Either'
@@ -393,17 +399,17 @@ export const mapKeysWith: MapKeysWith =
 /**
  * A KeyRemapLambda for remapping keys to camelCase
  *
- * @since 1.3.0
+ * @since 1.4.0
  * @category Combinators
  */
 export interface CamelCaseLambda extends KeyRemapLambda {
-  readonly output: CamelCase<this['input']>
+  readonly output: CamelCase<this['input'], { preserveConsecutiveUppercase: true }>
 }
 
 /**
  * Remap a struct's non-camel-cased-keys into camelCase
  *
- * @since 1.3.0
+ * @since 1.4.0
  * @category Combinators
  * @example
  *   import * as E from 'fp-ts/Either'
@@ -415,7 +421,7 @@ export interface CamelCaseLambda extends KeyRemapLambda {
  *     s.defineStruct({
  *       foo_bar: s.required(S.String),
  *       'bar-qux': s.optional(S.Number),
- *       'foo.baz-dan': s.optional(S.Boolean),
+ *       '--foo_baz-dan___': s.optional(S.Boolean),
  *     }),
  *   )
  *
@@ -425,12 +431,12 @@ export interface CamelCaseLambda extends KeyRemapLambda {
  *     DecoderMapMixedToCamel.decode({
  *       foo_bar: 'foo',
  *       'bar-qux': 1,
- *       'foo.baz-dan': true,
+ *       '--foo_baz-dan___': true,
  *     }),
  *     E.right({ fooBar: 'foo', barQux: 1, fooBazDan: true }),
  *   )
  */
-export const camelCaseKeys = mapKeysWith<CamelCaseLambda>(str => camelCase(`${str}`))
+export const camelCaseKeys = mapKeysWith<CamelCaseLambda>(camelCase)
 
 interface StructDefinition {
   /**

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -6,7 +6,7 @@
 import { identity } from 'fp-ts/function'
 import { HKT2, Kind, Kind2, URIS, URIS2 } from 'fp-ts/HKT'
 import { camelCase } from 'schemata-ts/internal/camelcase'
-import { CamelCase } from 'type-fest'
+import type { CamelCase } from 'type-fest'
 
 /**
  * @since 1.3.0

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -3,8 +3,10 @@
  *
  * @since 1.3.0
  */
+import { camelCase } from 'change-case'
 import { identity } from 'fp-ts/function'
 import { HKT2, Kind, Kind2, URIS, URIS2 } from 'fp-ts/HKT'
+import { CamelCase } from 'type-fest'
 
 /**
  * @since 1.3.0
@@ -387,6 +389,48 @@ export const mapKeysWith: MapKeysWith =
     }
     return remappedProps
   }
+
+/**
+ * A KeyRemapLambda for remapping keys to camelCase
+ *
+ * @since 1.3.0
+ * @category Combinators
+ */
+export interface CamelCaseLambda extends KeyRemapLambda {
+  readonly output: CamelCase<this['input']>
+}
+
+/**
+ * Remap a struct's non-camel-cased-keys into camelCase
+ *
+ * @since 1.3.0
+ * @category Combinators
+ * @example
+ *   import * as E from 'fp-ts/Either'
+ *   import { getDecoder } from 'schemata-ts/Decoder'
+ *   import * as S from 'schemata-ts/schemata'
+ *   import * as s from 'schemata-ts/struct'
+ *
+ *   const camelFromMixed = s.camelCaseKeys(
+ *     s.defineStruct({
+ *       foo_bar: s.required(S.String),
+ *       'bar-qux': s.optional(S.Number),
+ *       'foo.baz-dan': s.optional(S.Boolean),
+ *     }),
+ *   )
+ *
+ *   const DecoderMapMixedToCamel = getDecoder(S.StructM(camelFromMixed))
+ *
+ *   assert.deepStrictEqual(
+ *     DecoderMapMixedToCamel.decode({
+ *       foo_bar: 'foo',
+ *       'bar-qux': 1,
+ *       'foo.baz-dan': true,
+ *     }),
+ *     E.right({ fooBar: 'foo', barQux: 1, fooBazDan: true }),
+ *   )
+ */
+export const camelCaseKeys = mapKeysWith<CamelCaseLambda>(str => camelCase(`${str}`))
 
 interface StructDefinition {
   /**

--- a/tests/schemata/generic/CamelCaseFromMixed.test.ts
+++ b/tests/schemata/generic/CamelCaseFromMixed.test.ts
@@ -1,0 +1,147 @@
+import * as fc from 'fast-check'
+import * as E from 'fp-ts/Either'
+import { pipe } from 'fp-ts/function'
+import * as O from 'fp-ts/Option'
+import * as DE from 'io-ts/DecodeError'
+import * as Fsg from 'io-ts/FreeSemigroup'
+import { getArbitrary } from 'schemata-ts/Arbitrary'
+import { stripIdentity } from 'schemata-ts/base/JsonSchemaBase'
+import { getDecoder } from 'schemata-ts/Decoder'
+import { getEncoder } from 'schemata-ts/Encoder'
+import { getEq } from 'schemata-ts/Eq'
+import { getGuard } from 'schemata-ts/Guard'
+import { getJsonDeserializer } from 'schemata-ts/JsonDeserializer'
+import { getJsonSchema } from 'schemata-ts/JsonSchema'
+import { getJsonSerializer } from 'schemata-ts/JsonSerializer'
+import * as S from 'schemata-ts/schemata'
+
+const TestSchema = S.CamelCaseFromMixed({
+  __test: S.String,
+  'foo-bar': S.Natural,
+  FOO_BAZ: S.OptionFromNullable(S.BooleanFromNumber),
+  '_-_-_foo_Qux-----': S.String,
+  'foo.baz': S.String,
+  'some random sentence': S.Array(S.Ascii),
+})
+
+describe('CamelCaseFromMixed', () => {
+  const arbitrary = getArbitrary(TestSchema)
+  const encoder = getEncoder(TestSchema)
+  const eq = getEq(TestSchema)
+  const decoder = getDecoder(TestSchema)
+  const guard = getGuard(TestSchema)
+  const deserializer = getJsonDeserializer(TestSchema)
+  const serializer = getJsonSerializer(TestSchema)
+  const jsonSchema = getJsonSchema(TestSchema)
+  test('encoder', () => {
+    const valid: S.TypeOf<typeof TestSchema> = {
+      test: 'test',
+      fooBar: 5 as any,
+      fooBaz: O.some(false),
+      fooQux: 'test',
+      'foo.baz': 'test',
+      someRandomSentence: ['test' as any],
+    }
+    const result = encoder.encode(valid)
+    expect(result).toEqual({
+      __test: 'test',
+      'foo-bar': 5,
+      FOO_BAZ: 0,
+      '_-_-_foo_Qux-----': 'test',
+      'foo.baz': 'test',
+      'some random sentence': ['test'],
+    })
+  })
+  test('encoder / guard', () => {
+    fc.assert(fc.property(arbitrary.arbitrary(fc), guard.is))
+  })
+  test('eq', () => {
+    fc.assert(
+      fc.property(arbitrary.arbitrary(fc), a => {
+        expect(eq.equals(a, a)).toBe(true)
+      }),
+    )
+  })
+  describe('decoder', () => {
+    it('should invalidate invalid inputs', () => {
+      const valid: S.InputOf<typeof TestSchema> = {
+        __test: 'test',
+        'foo-bar': 5.5,
+        FOO_BAZ: -1,
+        '_-_-_foo_Qux-----': 'test',
+        'foo.baz': 'test',
+        'some random sentence': ['ｶﾀｶﾅ'],
+      }
+      const result = decoder.decode(valid)
+      expect(result).toEqual(
+        E.left(
+          Fsg.concat(
+            Fsg.of(DE.key('foo-bar', DE.required, Fsg.of(DE.leaf(5.5, 'int')))),
+            Fsg.of(
+              DE.key(
+                'some random sentence',
+                DE.required,
+                Fsg.of(DE.index(0, DE.optional, Fsg.of(DE.leaf('ｶﾀｶﾅ', 'Ascii')))),
+              ),
+            ),
+          ),
+        ),
+      )
+    })
+    it('should validate valid inputs', () => {
+      const valid: S.InputOf<typeof TestSchema> = {
+        __test: 'test',
+        'foo-bar': 5,
+        FOO_BAZ: 0,
+        '_-_-_foo_Qux-----': 'test',
+        'foo.baz': 'test',
+        'some random sentence': ['test'],
+      }
+      const result = decoder.decode(valid)
+      expect(result).toEqual({
+        _tag: 'Right',
+        right: {
+          test: 'test',
+          fooBar: 5,
+          fooBaz: O.some(false),
+          fooQux: 'test',
+          'foo.baz': 'test',
+          someRandomSentence: ['test'],
+        },
+      })
+    })
+  })
+  test('serializer / deserializer', () => {
+    fc.assert(
+      fc.property(arbitrary.arbitrary(fc), a => {
+        const serialized = serializer.print(a)
+        const deserialized = pipe(serialized, E.chainW(deserializer.parse))
+        expect(deserialized).toEqual(E.right(a))
+      }),
+    )
+  })
+  test('json schema', () => {
+    expect(stripIdentity(jsonSchema)).toEqual({
+      type: 'object',
+      properties: {
+        __test: { type: 'string' },
+        'foo-bar': { type: 'integer', minimum: 0, maximum: 9007199254740991 },
+        FOO_BAZ: { oneOf: [{ type: 'number' }, { type: 'null', const: null }] },
+        '_-_-_foo_Qux-----': { type: 'string' },
+        'foo.baz': { type: 'string' },
+        'some random sentence': {
+          type: 'array',
+          items: { type: 'string', description: 'Ascii', pattern: '^([\\x00-\\x7f]+?)$' },
+        },
+      },
+      required: [
+        'FOO_BAZ',
+        '_-_-_foo_Qux-----',
+        '__test',
+        'foo-bar',
+        'foo.baz',
+        'some random sentence',
+      ],
+    })
+  })
+})

--- a/tests/struct.test.ts
+++ b/tests/struct.test.ts
@@ -213,6 +213,18 @@ describe('value-level tests', () => {
       const arb = getArbitrary(S.StructM(testStructCamel))
       fc.assert(fc.property(arb.arbitrary(fc), guard.is))
     })
+    test('arb / encoder / decoder round trip', () => {
+      const encoder = getEncoder(S.StructM(testStructCamel))
+      const decoder = getDecoder(S.StructM(testStructCamel))
+      const arb = getArbitrary(S.StructM(testStructCamel))
+      fc.assert(
+        fc.property(arb.arbitrary(fc), x => {
+          const encoded = encoder.encode(x)
+          const decoded = decoder.decode(encoded)
+          expect(decoded).toEqual(D.success(x))
+        }),
+      )
+    })
   })
   describe('remap keys', () => {
     test('encoder', () => {
@@ -234,6 +246,18 @@ describe('value-level tests', () => {
       const guard = getGuard(capsTestStruct)
       const arb = getArbitrary(capsTestStruct)
       fc.assert(fc.property(arb.arbitrary(fc), guard.is))
+    })
+    test('arb / encoder / decoder round trip', () => {
+      const encoder = getEncoder(capsTestStruct)
+      const decoder = getDecoder(capsTestStruct)
+      const arb = getArbitrary(capsTestStruct)
+      fc.assert(
+        fc.property(arb.arbitrary(fc), x => {
+          const encoded = encoder.encode(x)
+          const decoded = decoder.decode(encoded)
+          expect(decoded).toEqual(D.success(x))
+        }),
+      )
     })
   })
   describe('partial', () => {

--- a/tests/struct.test.ts
+++ b/tests/struct.test.ts
@@ -332,19 +332,19 @@ describe('value-level tests', () => {
   })
   describe('struct', () => {
     test('encoder', () => {
-      const partial = getEncoder(S.StructM(s.complete(plainStruct)))
-      expect(partial.encode({ a: 'a', b: true })).toEqual({
+      const encoder = getEncoder(S.StructM(plainStruct))
+      expect(encoder.encode({ a: 'a', b: true })).toEqual({
         a: 'a',
         b: 1,
       })
     })
     test('decoder', () => {
-      const partial = getDecoder(S.StructM(s.complete(plainStruct)))
-      expect(partial.decode({ a: 'a', b: 0 })).toEqual(D.success({ a: 'a', b: false }))
+      const decoder = getDecoder(S.StructM(plainStruct))
+      expect(decoder.decode({ a: 'a', b: 0 })).toEqual(D.success({ a: 'a', b: false }))
     })
     test('arb / guard', () => {
-      const g = getGuard(S.StructM(s.complete(plainStruct)))
-      const arb = getArbitrary(S.StructM(s.complete(plainStruct)))
+      const g = getGuard(S.StructM(plainStruct))
+      const arb = getArbitrary(S.StructM(plainStruct))
       fc.assert(fc.property(arb.arbitrary(fc), g.is))
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2395,14 +2395,6 @@ callsites@^3.0.0, callsites@^3.1.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-camel-case@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
-  integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
-  dependencies:
-    pascal-case "^3.1.2"
-    tslib "^2.0.3"
-
 camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -2417,15 +2409,6 @@ caniuse-lite@^1.0.30001370:
   version "1.0.30001393"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001393.tgz#1aa161e24fe6af2e2ccda000fc2b94be0b0db356"
   integrity sha512-N/od11RX+Gsk+1qY/jbPa0R6zJupEa0lxeBG598EbrtblxVCTJsQwbRBm6+V+rxpc5lHKdsXb9RY83cZIPLseA==
-
-capital-case@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/capital-case/-/capital-case-1.0.4.tgz#9d130292353c9249f6b00fa5852bee38a717e669"
-  integrity sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
-    upper-case-first "^2.0.2"
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -2460,24 +2443,6 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
-
-change-case@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/change-case/-/change-case-4.1.2.tgz#fedfc5f136045e2398c0410ee441f95704641e12"
-  integrity sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==
-  dependencies:
-    camel-case "^4.1.2"
-    capital-case "^1.0.4"
-    constant-case "^3.0.4"
-    dot-case "^3.0.4"
-    header-case "^2.0.4"
-    no-case "^3.0.4"
-    param-case "^3.0.4"
-    pascal-case "^3.1.2"
-    path-case "^3.0.4"
-    sentence-case "^3.0.4"
-    snake-case "^3.0.4"
-    tslib "^2.0.3"
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -2741,15 +2706,6 @@ configstore@^5.0.1:
     unique-string "^2.0.0"
     write-file-atomic "^3.0.0"
     xdg-basedir "^4.0.0"
-
-constant-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/constant-case/-/constant-case-3.0.4.tgz#3b84a9aeaf4cf31ec45e6bf5de91bdfb0589faf1"
-  integrity sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
-    upper-case "^2.0.2"
 
 convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.8.0"
@@ -3119,14 +3075,6 @@ domutils@^2.5.2:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
-
-dot-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"
-  integrity sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
 
 dot-prop@^5.2.0:
   version "5.3.0"
@@ -4101,14 +4049,6 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
-
-header-case@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/header-case/-/header-case-2.0.4.tgz#5a42e63b55177349cf405beb8d775acabb92c063"
-  integrity sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==
-  dependencies:
-    capital-case "^1.0.4"
-    tslib "^2.0.3"
 
 hosted-git-info@^2.1.4:
   version "2.8.9"
@@ -5351,13 +5291,6 @@ longest-streak@^2.0.0:
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
   integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
 
-lower-case@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
-  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
-  dependencies:
-    tslib "^2.0.3"
-
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -5982,14 +5915,6 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-no-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
-  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
-  dependencies:
-    lower-case "^2.0.2"
-    tslib "^2.0.3"
-
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -6216,14 +6141,6 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-param-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
-  integrity sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
-  dependencies:
-    dot-case "^3.0.4"
-    tslib "^2.0.3"
-
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -6270,26 +6187,10 @@ parse5@6.0.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
-pascal-case@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
-  integrity sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
-
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==
-
-path-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/path-case/-/path-case-3.0.4.tgz#9168645334eb942658375c56f80b4c0cb5f82c6f"
-  integrity sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==
-  dependencies:
-    dot-case "^3.0.4"
-    tslib "^2.0.3"
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -6823,15 +6724,6 @@ semver@^7.2.1:
   dependencies:
     lru-cache "^6.0.0"
 
-sentence-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-3.0.4.tgz#3645a7b8c117c787fde8702056225bb62a45131f"
-  integrity sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
-    upper-case-first "^2.0.2"
-
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -6947,14 +6839,6 @@ slice-ansi@^5.0.0:
   dependencies:
     ansi-styles "^6.0.0"
     is-fullwidth-code-point "^4.0.0"
-
-snake-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-3.0.4.tgz#4f2bbd568e9935abdfd593f34c691dadb49c452c"
-  integrity sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==
-  dependencies:
-    dot-case "^3.0.4"
-    tslib "^2.0.3"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -7481,11 +7365,6 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
-  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
-
 tslib@^2.1.0, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
@@ -7693,20 +7572,6 @@ update-section@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/update-section/-/update-section-0.3.3.tgz#458f17820d37820dc60e20b86d94391b00123158"
   integrity sha512-BpRZMZpgXLuTiKeiu7kK0nIPwGdyrqrs6EDSaXtjD/aQ2T+qVo9a5hRC3HN3iJjCMxNT/VxoLGQ7E/OzE5ucnw==
-
-upper-case-first@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-2.0.2.tgz#992c3273f882abd19d1e02894cc147117f844324"
-  integrity sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==
-  dependencies:
-    tslib "^2.0.3"
-
-upper-case@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-2.0.2.tgz#d89810823faab1df1549b7d97a76f8662bae6f7a"
-  integrity sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==
-  dependencies:
-    tslib "^2.0.3"
 
 uri-js@^4.2.2:
   version "4.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2395,6 +2395,14 @@ callsites@^3.0.0, callsites@^3.1.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camel-case@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
+  integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
+  dependencies:
+    pascal-case "^3.1.2"
+    tslib "^2.0.3"
+
 camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -2409,6 +2417,15 @@ caniuse-lite@^1.0.30001370:
   version "1.0.30001393"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001393.tgz#1aa161e24fe6af2e2ccda000fc2b94be0b0db356"
   integrity sha512-N/od11RX+Gsk+1qY/jbPa0R6zJupEa0lxeBG598EbrtblxVCTJsQwbRBm6+V+rxpc5lHKdsXb9RY83cZIPLseA==
+
+capital-case@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/capital-case/-/capital-case-1.0.4.tgz#9d130292353c9249f6b00fa5852bee38a717e669"
+  integrity sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case-first "^2.0.2"
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -2443,6 +2460,24 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+change-case@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/change-case/-/change-case-4.1.2.tgz#fedfc5f136045e2398c0410ee441f95704641e12"
+  integrity sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==
+  dependencies:
+    camel-case "^4.1.2"
+    capital-case "^1.0.4"
+    constant-case "^3.0.4"
+    dot-case "^3.0.4"
+    header-case "^2.0.4"
+    no-case "^3.0.4"
+    param-case "^3.0.4"
+    pascal-case "^3.1.2"
+    path-case "^3.0.4"
+    sentence-case "^3.0.4"
+    snake-case "^3.0.4"
+    tslib "^2.0.3"
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -2706,6 +2741,15 @@ configstore@^5.0.1:
     unique-string "^2.0.0"
     write-file-atomic "^3.0.0"
     xdg-basedir "^4.0.0"
+
+constant-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/constant-case/-/constant-case-3.0.4.tgz#3b84a9aeaf4cf31ec45e6bf5de91bdfb0589faf1"
+  integrity sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case "^2.0.2"
 
 convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.8.0"
@@ -3075,6 +3119,14 @@ domutils@^2.5.2:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
+
+dot-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"
+  integrity sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
 
 dot-prop@^5.2.0:
   version "5.3.0"
@@ -4049,6 +4101,14 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+header-case@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/header-case/-/header-case-2.0.4.tgz#5a42e63b55177349cf405beb8d775acabb92c063"
+  integrity sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==
+  dependencies:
+    capital-case "^1.0.4"
+    tslib "^2.0.3"
 
 hosted-git-info@^2.1.4:
   version "2.8.9"
@@ -5291,6 +5351,13 @@ longest-streak@^2.0.0:
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
   integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
 
+lower-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
+  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
+  dependencies:
+    tslib "^2.0.3"
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -5915,6 +5982,14 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+no-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
+  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
+  dependencies:
+    lower-case "^2.0.2"
+    tslib "^2.0.3"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -6141,6 +6216,14 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+param-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
+  integrity sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -6187,10 +6270,26 @@ parse5@6.0.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
+pascal-case@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
+  integrity sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==
+
+path-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/path-case/-/path-case-3.0.4.tgz#9168645334eb942658375c56f80b4c0cb5f82c6f"
+  integrity sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -6724,6 +6823,15 @@ semver@^7.2.1:
   dependencies:
     lru-cache "^6.0.0"
 
+sentence-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-3.0.4.tgz#3645a7b8c117c787fde8702056225bb62a45131f"
+  integrity sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case-first "^2.0.2"
+
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -6839,6 +6947,14 @@ slice-ansi@^5.0.0:
   dependencies:
     ansi-styles "^6.0.0"
     is-fullwidth-code-point "^4.0.0"
+
+snake-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-3.0.4.tgz#4f2bbd568e9935abdfd593f34c691dadb49c452c"
+  integrity sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -7365,6 +7481,11 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.0.3:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
 tslib@^2.1.0, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
@@ -7415,6 +7536,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^3.5.7:
+  version "3.5.7"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.5.7.tgz#1ee9efc9a172f4002c40b896689928a7bba537f2"
+  integrity sha512-6J4bYzb4sdkcLBty4XW7F18VPI66M4boXNE+CY40532oq2OJe6AVMB5NmjOp6skt/jw5mRjz/hLRpuglz0U+FA==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
@@ -7567,6 +7693,20 @@ update-section@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/update-section/-/update-section-0.3.3.tgz#458f17820d37820dc60e20b86d94391b00123158"
   integrity sha512-BpRZMZpgXLuTiKeiu7kK0nIPwGdyrqrs6EDSaXtjD/aQ2T+qVo9a5hRC3HN3iJjCMxNT/VxoLGQ7E/OzE5ucnw==
+
+upper-case-first@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-2.0.2.tgz#992c3273f882abd19d1e02894cc147117f844324"
+  integrity sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==
+  dependencies:
+    tslib "^2.0.3"
+
+upper-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-2.0.2.tgz#d89810823faab1df1549b7d97a76f8662bae6f7a"
+  integrity sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==
+  dependencies:
+    tslib "^2.0.3"
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
Closes #255 

Introduces a powerful type operator and utility function for transforming a struct definition's output keys with a mapping function.  And adds a camelcase keys utility.

```typescript
import * as E from 'fp-ts/Either'
import { getDecoder } from 'schemata-ts/Decoder'
import * as S from 'schemata-ts/schemata'
import * as s from 'schemata-ts/struct'

const camelFromMixed = s.camelCaseKeys(
  s.defineStruct({
    foo_bar: s.required(S.String),
    'bar-qux': s.optional(S.Number),
    'foo.baz-dan': s.optional(S.Boolean),
  }),
)

const DecoderMapMixedToCamel = getDecoder(S.StructM(camelFromMixed))

assert.deepStrictEqual(
  DecoderMapMixedToCamel.decode({
    foo_bar: 'foo',
    'bar-qux': 1,
    'foo.baz-dan': true,
  }),
  E.right({ fooBar: 'foo', barQux: 1, fooBazDan: true }),
)
```