### PR TITLE
#265 Fix: Optional Json Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ yarn add schemata-ts
 npm install schemata-ts
 ```
 
+### PNPM
+
+```bash
+pnpm add schemata-ts
+```
+
 ## Documentation
 
 - [schemata-ts](https://jacob-alford.github.io/schemata-ts/modules/schemata.ts.html)

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Schemata-ts comes with its own implementation of [JSON-Schema](https://json-sche
 
 ### Annotating JSON schema
 
-JSON schema can have description and titles fields. To specify these values, you should use `S.Annotate`:
+JSON schema can have description and title fields. To specify these values, you should use `S.Annotate`:
 
 ```typescript
 import * as S from 'schemata-ts/schemata'

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,18 @@ yarn add schemata-ts
 npm install schemata-ts
 ```
 
+### PNPM
+
+```bash
+pnpm add schemata-ts
+```
+
+## Documentation
+
+- [schemata-ts](https://jacob-alford.github.io/schemata-ts/modules/schemata.ts.html)
+- [fp-ts](https://gcanti.github.io/fp-ts/modules/)
+- [io-ts](https://gcanti.github.io/io-ts)
+
 ## Codec and Arbitrary
 
 A codec is a typeclass that contains the methods of `Decoder`, `Encoder`, `JsonSerializer`, `JsonDeserializer`, and `Guard`. Decoder and encoder are lossless when composed together. This means that for all domain types for which an encoder encodes to, a decoder will return a valid `E.Right` value.
@@ -139,7 +151,58 @@ Anything that successfully stringifies using `JsonSerializer` will successfully 
 
 Schemata-ts comes with its own implementation of [JSON-Schema](https://json-schema.org/) and is a validation standard that can be used to validate artifacts in many other languages and frameworks. Schemata-ts's implementation is compatible with JSON Schema Draft 4, Draft 6, Draft 7, Draft 2019-09, and has partial support for 2020-12. _Note_: string `format` (like regex, contentType, or mediaType) is only available starting with Draft 6, and tuples are not compatible with Draft 2020-12.
 
-### Customer JSON Schema Example
+### Annotating JSON schema
+
+JSON schema can have description and title fields. To specify these values, you should use `S.Annotate`:
+
+```typescript
+import * as S from 'schemata-ts/schemata'
+
+const Name = pipe(
+  S.String,
+  S.Annotate({
+    title: 'Name',
+    description: 'The name of the person',
+  }),
+)
+
+const Email = pipe(
+  S.EmailAddress,
+  S.Annotate({
+    title: 'Email',
+    description: 'The email address of the person',
+  }),
+)
+
+const Street = pipe(
+  S.String,
+  S.Annotate({
+    title: 'Street',
+    description: 'The street address of the person',
+  }),
+)
+
+const City = pipe(
+  S.String,
+  S.Annotate({
+    title: 'City',
+    description: 'The city of the person',
+  }),
+)
+
+const Address = S.Struct({
+  street: Street,
+  city: City,
+})
+
+const Person = S.Struct({
+  name: Name,
+  email: Email,
+  address: Address,
+})
+```
+
+### JSON Schema Example
 
 This is a live example generating a JSON Schema in `src/base/JsonSchemaBase.ts`
 
@@ -217,217 +280,6 @@ assert.equal(PB.regexFromPattern(usPhoneNumber).test('123-456-7890'), true)
 assert.equal(PB.regexFromPattern(usPhoneNumber).test('1234567890'), false)
 ```
 
-## Advanced Structs and Key Transformations
+## Under the hood
 
-Schemata-ts has powerful tools for constructing domain artifacts that are strongly-typed plain javascript objects. There are a few ways to build the same schema, and some ways are more powerful than others. If, for instance, domain types are fragmented and need to compose in different ways, they can't be changed once they've been turned into schemata. `schemata-ts/struct` has built-in combinators for composing struct definitions together in elegant ways.
-
-### Declaring a struct schema
-
-There are a few ways to declare a struct-based schema. The first is to use the `Struct` schema exported with all the other schemata from `schemata-ts/schemata`:
-
-```typescript
-import * as E from 'fp-ts/Either'
-import * as S from 'schemata-ts/schemata'
-import { getDecoder } from 'schemata-ts/Decoder'
-
-const SomeDomainType = S.Struct({
-  a: S.String,
-  b: S.BooleanFromNumber,
-})
-
-// SomeDomainType will have the type:
-// SchemaExt<{ a: string, b: number }, { a: string, b: boolean }>
-
-const decoder = getDecoder(SomeDomainType)
-
-assert.deepStrictEqual(
-  decoder.decode({
-    a: 'foo',
-    b: 0,
-  }),
-  E.right({
-    a: 'foo',
-    b: false,
-  }),
-)
-```
-
-The next few ways use the `schemata-ts/struct` module to define meta-definitions of structs. Once the struct has been constructed as it needs, it can be plugged into the `StructM` schema, and used anywhere else schemata are used.
-
-The following results in the same schema as defined in the above example:
-
-```typescript
-import * as S from 'schemata-ts/schemata'
-import * as s from 'schemata-ts/struct'
-import { getEncoder } from 'schemata-ts/Encoder'
-
-const someDomainType = s.struct({
-  a: S.String,
-  b: S.BooleanFromNumber,
-})
-
-const SomeDomainTypeSchema = S.StructM(someDomainType)
-
-// SomeDomainType will have the type:
-// SchemaExt<{ a: string, b: number }, { a: string, b: boolean }>
-
-const encoder = getEncoder(SomeDomainTypeSchema)
-
-assert.deepStrictEqual(
-  encoder.encode({
-    a: 'foo',
-    b: false,
-  }),
-  {
-    a: 'foo',
-    b: 0,
-  },
-)
-```
-
-The final way to write this domain type is to use `struct.defineStruct` which differs from `struct` in that each property key must explicitly specify whether the key is required or optional.
-
-The following results in the same schema as defined in the above two examples:
-
-```typescript
-import * as fc from 'fast-check'
-import * as S from 'schemata-ts/schemata'
-import * as s from 'schemata-ts/struct'
-import { getGuard } from 'schemata-ts/Guard'
-import { getArbitrary } from 'schemata-ts/Arbitrary'
-
-const someDomainType = s.defineStruct({
-  a: s.required(S.String),
-  b: s.required(S.BooleanFromNumber),
-})
-
-const SomeDomainTypeSchema = S.StructM(someDomainType)
-
-// SomeDomainType will have the type:
-// SchemaExt<{ a: string, b: number }, { a: string, b: boolean }>
-
-const arbitrary = getArbitrary(SomeDomainTypeSchema).arbitrary(fc)
-const guard = getGuard(SomeDomainTypeSchema)
-
-fc.assert(fc.property(arbitrary, guard.is))
-```
-
-### CamelCase Keys
-
-As of 1.4.0, schemata-ts has built in combinators for constructing domain types where the expected input type contains mixed case keys (words separated by [any whitespace character](https://en.wikipedia.org/wiki/Whitespace_character#Unicode), hyphens, and underscores) whose output is camelCase. Like struct above, there are a few ways to do this. This first example is using the `CamelCaseFromMixed` schema of `schemata-ts/schemata`.
-
-```typescript
-import * as E from 'fp-ts/Either'
-import * as S from 'schemata-ts/schemata'
-import { getDecoder } from 'schemata-ts/Decoder'
-
-const DatabasePerson = S.CamelCaseFromMixed({
-  first_name: S.String,
-  last_name: S.String,
-  age: S.Number,
-  is_married: S.BooleanFromString,
-})
-
-// DatabasePerson will have the type:
-// SchemaExt<
-//   { first_name: string, last_name: string, age: number, is_married: string },
-//   { firstName: string, lastName: string, age: number, isMarried: boolean }
-// >
-
-const decoder = getDecoder(DatabasePerson)
-
-assert.deepStrictEqual(
-  decoder.decode({
-    first_name: 'John',
-    last_name: 'Doe',
-    age: 42,
-    is_married: 'false',
-  }),
-  E.right({
-    firstName: 'John',
-    lastName: 'Doe',
-    age: 42,
-    isMarried: false,
-  }),
-)
-```
-
-The following example is identical to the above except it uses the `camelCaseKeys` combinator of the struct module.
-
-```typescript
-import * as S from 'schemata-ts/schemata'
-import * as s from 'schemata-ts/struct'
-import { getEncoder } from 'schemata-ts/Encoder'
-
-const databasePerson = s.struct({
-  first_name: S.String,
-  last_name: S.String,
-  age: S.Number,
-  is_married: S.BooleanFromString,
-})
-
-const DatabasePerson = S.StructM(s.camelCaseKeys(databasePerson))
-
-// DatabasePerson will have the type:
-// SchemaExt<
-//   { first_name: string, last_name: string, age: number, is_married: string },
-//   { firstName: string, lastName: string, age: number, isMarried: boolean }
-// >
-
-const encoder = getEncoder(DatabasePerson)
-
-assert.deepStrictEqual(
-  encoder.encode({
-    firstName: 'John',
-    lastName: 'Doe',
-    age: 42,
-    isMarried: false,
-  }),
-  {
-    first_name: 'John',
-    last_name: 'Doe',
-    age: 42,
-    is_married: 'false',
-  },
-)
-```
-
-The following example is identical to the above, except the keys being mapped to are explicitly specified using `defineStruct`:
-
-```typescript
-import * as fc from 'fast-check'
-import * as S from 'schemata-ts/schemata'
-import * as s from 'schemata-ts/struct'
-import { getArbitrary } from 'schemata-ts/Arbitrary'
-import { getGuard } from 'schemata-ts/Guard'
-
-const databasePerson = s.defineStruct({
-  first_name: s.mapKeyTo('firstName')(s.required(S.String)),
-  last_name: s.mapKeyTo('lastName')(s.required(S.String)),
-  age: s.required(S.Number),
-  is_married: s.mapKeyTo('isMarried')(s.required(S.BooleanFromString)),
-})
-
-const DatabasePerson = S.StructM(databasePerson)
-
-// DatabasePerson will have the type:
-// SchemaExt<
-//   { first_name: string, last_name: string, age: number, is_married: string },
-//   { firstName: string, lastName: string, age: number, isMarried: boolean }
-// >
-
-const arbitrary = getArbitrary(DatabasePerson).arbitrary(fc)
-const guard = getGuard(DatabasePerson)
-
-fc.assert(fc.property(arbitrary, guard.is))
-```
-
-Furthermore, `schemata-ts` has several utilities for working with structs:
-
-| Name      | Description                                  |
-| --------- | -------------------------------------------- |
-| partial   | Marks all properties as optional             |
-| complete  | Marks all properties as required             |
-| pick      | Keep only specified keys                     |
-| omit      | Remove specified keys                        |
-| mapKeysTo | Apply a mapping function to an object's keys |
+`Schemata-ts` uses the io-ts v2 system of Schemables. Schemata internally are just plain functions in a service oriented fashion that take as their principle parameter a `Schemable`. Schemables consist of a variety of methods that are used by `schemata-ts`'s large collection of schemata to determine behavior. By using the various `derivation` methods, such as `getDecoder`, `getEncoder`, `getJsonSchema`, `getArbitrary`, etc. you provide the schemable particular to that data-type thus resolving the schema.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "schemata-ts",
-  "version": "1.4.2",
-  "description": "A collection of Schemata inspired by io-ts-types and validators.js",
+  "version": "1.4.3",
+  "description": "Write domain types once. A schema engine based on io-ts v2 with a collection of schemata inspired by io-ts-types and validators.js",
   "homepage": "https://jacob-alford.github.io/schemata-ts/",
   "repository": {
     "type": "git",

--- a/src/base/JsonSchemaBase.ts
+++ b/src/base/JsonSchemaBase.ts
@@ -40,6 +40,7 @@ import * as Str from 'fp-ts/string'
 import { memoize } from 'io-ts/Schemable'
 import { Schemable2 } from 'schemata-ts/base/SchemableBase'
 import { Int } from 'schemata-ts/schemables/WithInt/definition'
+import { hasImplicitOptional } from 'schemata-ts/schemables/WithOptional/utils'
 
 // -------------------------------------------------------------------------------------
 // Model
@@ -506,8 +507,13 @@ export const Schemable: Schemable2<URI> = {
   number: makeNumberSchema(),
   boolean: booleanSchema,
   nullable: schema => make(new JsonUnion([schema, nullSchema])),
-  // @ts-expect-error -- typelevel difference
-  struct: s => makeStructSchema(s, Object.keys(s)),
+  struct: s =>
+    // @ts-expect-error -- typelevel difference
+    makeStructSchema(
+      s,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      Object.keys(s).filter(k => !hasImplicitOptional(s[k]!)),
+    ),
   // @ts-expect-error -- typelevel difference
   partial: makeStructSchema,
   record: makeRecordSchema,

--- a/src/schemables/WithOptional/instances/json-schema.ts
+++ b/src/schemables/WithOptional/instances/json-schema.ts
@@ -5,12 +5,12 @@
  */
 import * as JS from 'schemata-ts/base/JsonSchemaBase'
 import { WithOptional2 } from 'schemata-ts/schemables/WithOptional/definition'
+import { makeImplicitOptional } from 'schemata-ts/schemables/WithOptional/utils'
 
 /**
  * @since 1.2.0
  * @category Instances
  */
 export const JsonSchema: WithOptional2<JS.URI> = {
-  // Undefined is not a valid JSON Value
-  optional: () => JS.emptySchema,
+  optional: inner => makeImplicitOptional(inner, _ => Object.assign({}, _)),
 }

--- a/src/schemables/WithOptional/utils.ts
+++ b/src/schemables/WithOptional/utils.ts
@@ -1,0 +1,16 @@
+import { hasOwn } from 'schemata-ts/internal/util'
+
+const OptionalSymbol = Symbol.for('schemata-ts/schemable/WithOptional')
+type OptionalSymbol = typeof OptionalSymbol
+
+interface ImplicitOptional {
+  [OptionalSymbol]: OptionalSymbol
+}
+
+/** @internal */
+export const makeImplicitOptional = <A>(a: A, clone: (a: A) => A): ImplicitOptional & A =>
+  Object.assign(clone(a) as any, { [OptionalSymbol]: OptionalSymbol }) as any
+
+/** @internal */
+export const hasImplicitOptional = (a: object): a is ImplicitOptional =>
+  hasOwn(a, OptionalSymbol)

--- a/tests/JsonSchema.test.ts
+++ b/tests/JsonSchema.test.ts
@@ -215,7 +215,11 @@ describe('JsonSchema', () => {
               { type: 'null', const: null },
             ],
           },
-          optUndefined: {},
+          optUndefined: {
+            maximum: 1,
+            minimum: 0,
+            type: 'number',
+          },
         },
         required: [],
       })

--- a/tests/schemables/WithOptional.test.ts
+++ b/tests/schemables/WithOptional.test.ts
@@ -1,3 +1,8 @@
+import { pipe } from 'fp-ts/function'
+import { getJsonSchema } from 'schemata-ts/JsonSchema'
+import * as S from 'schemata-ts/schemata'
+
+import * as JS from '../../src/base/JsonSchemaBase'
 import * as SC from '../../src/base/SchemaBase'
 import { getGuard } from '../../src/Guard'
 import * as WithOptional from '../../test-utils/schemable-exports/WithOptional'
@@ -8,5 +13,41 @@ describe('WithOptional', () => {
     expect(Guard.is('a')).toBe(true)
     expect(Guard.is(undefined)).toBe(true)
     expect(Guard.is(1)).toBe(false)
+  })
+})
+
+describe('#265 optional schemas lose properties', () => {
+  const AnnotatedOptionalStruct = pipe(
+    S.Optional(S.Struct({ field: S.String })),
+    S.Annotate({
+      title: 'Annotated optional struct',
+      description: 'Description of the annotated optional struct',
+    }),
+  )
+
+  const exampleSchema = S.Struct({
+    annotatedOptionalStruct: AnnotatedOptionalStruct,
+  })
+
+  const jsonSchema = JS.stripIdentity(getJsonSchema(exampleSchema))
+
+  test('optional retains property information and relays optionality to parent', () => {
+    expect(jsonSchema).toStrictEqual({
+      type: 'object',
+      properties: {
+        annotatedOptionalStruct: {
+          type: 'object',
+          title: 'Annotated optional struct',
+          description: 'Description of the annotated optional struct',
+          properties: {
+            field: {
+              type: 'string',
+            },
+          },
+          required: ['field'],
+        },
+      },
+      required: [],
+    })
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "allowJs": false,
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "lib": ["DOM", "ESNext"],
 
     "module": "CommonJS",


### PR DESCRIPTION
- Optional Json Schema no longer wrongly remove inner schema properties
- Optional Json Schema will relay optionality to its parent, and will no longer be present in `required` fields

closes #265 