### PR TITLE
Simplify Arbitrary

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ export const User = S.Struct({
 export type User = S.TypeOf<typeof User>
 export type UserInput = S.InputOf<typeof User>
 
-export const userArbitrary = getArbitrary(User).arbitrary(fc)
+export const userArbitrary = getArbitrary(User)
 export const userCodec = getCodec(User)
 
 const validInput = {
@@ -339,7 +339,7 @@ const SomeDomainTypeSchema = S.StructM(someDomainType)
 // SomeDomainType will have the type:
 // Schema<{ a: string, b: number }, { a: string, b: boolean }>
 
-const arbitrary = getArbitrary(SomeDomainTypeSchema).arbitrary(fc)
+const arbitrary = getArbitrary(SomeDomainTypeSchema)
 const guard = getGuard(SomeDomainTypeSchema)
 
 fc.assert(fc.property(arbitrary, guard.is))
@@ -449,7 +449,7 @@ const DatabasePerson = S.StructM(databasePerson)
 //   { firstName: string, lastName: string, age: number, isMarried: boolean }
 // >
 
-const arbitrary = getArbitrary(DatabasePerson).arbitrary(fc)
+const arbitrary = getArbitrary(DatabasePerson)
 const guard = getGuard(DatabasePerson)
 
 fc.assert(fc.property(arbitrary, guard.is))

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ export const User = S.Struct({
 export type User = S.TypeOf<typeof User>
 export type UserInput = S.InputOf<typeof User>
 
-export const userArbitrary = getArbitrary(User).arbitrary(fc)
+export const userArbitrary = getArbitrary(User)
 export const userCodec = getCodec(User)
 
 const validInput = {
@@ -306,7 +306,7 @@ const SomeDomainTypeSchema = S.StructM(someDomainType)
 // SomeDomainType will have the type:
 // Schema<{ a: string, b: number }, { a: string, b: boolean }>
 
-const arbitrary = getArbitrary(SomeDomainTypeSchema).arbitrary(fc)
+const arbitrary = getArbitrary(SomeDomainTypeSchema)
 const guard = getGuard(SomeDomainTypeSchema)
 
 fc.assert(fc.property(arbitrary, guard.is))
@@ -416,7 +416,7 @@ const DatabasePerson = S.StructM(databasePerson)
 //   { firstName: string, lastName: string, age: number, isMarried: boolean }
 // >
 
-const arbitrary = getArbitrary(DatabasePerson).arbitrary(fc)
+const arbitrary = getArbitrary(DatabasePerson)
 const guard = getGuard(DatabasePerson)
 
 fc.assert(fc.property(arbitrary, guard.is))

--- a/src/Arbitrary.ts
+++ b/src/Arbitrary.ts
@@ -3,15 +3,7 @@
  *
  * @since 1.0.0
  */
-import type * as FastCheck from 'fast-check'
-
-/**
- * @since 1.0.0
- * @category Model
- */
-export interface Arbitrary<A> {
-  readonly arbitrary: (fc: typeof FastCheck) => FastCheck.Arbitrary<A>
-}
+import type * as fc from 'fast-check'
 
 // ------------------
 // combinators
@@ -45,6 +37,6 @@ export type URI = typeof URI
 
 declare module 'fp-ts/lib/HKT' {
   interface URItoKind<A> {
-    readonly Arbitrary: Arbitrary<A>
+    readonly Arbitrary: fc.Arbitrary<A>
   }
 }

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -26,7 +26,7 @@
  *   export type User = S.TypeOf<typeof User>
  *   export type UserInput = S.InputOf<typeof User>
  *
- *   export const arbitrary = getArbitrary(User).arbitrary(fc)
+ *   export const arbitrary = getArbitrary(User)
  *   export const codec = getCodec(User)
  *   export const eq = getEq(User)
  *

--- a/src/internal/arbitrary.ts
+++ b/src/internal/arbitrary.ts
@@ -1,17 +1,5 @@
-import type * as FastCheck from 'fast-check'
+import type * as fc from 'fast-check'
 import type * as hkt from 'schemata-ts/internal/schemable'
-import { memoize } from 'schemata-ts/Schema'
-
-export interface Arbitrary<A> {
-  readonly arbitrary: (fc: typeof FastCheck) => FastCheck.Arbitrary<A>
-}
-
-/** @internal */
-export const makeArbitrary = <A>(
-  arbitrary: (fc: typeof FastCheck) => FastCheck.Arbitrary<A>,
-): Arbitrary<A> => ({
-  arbitrary: memoize(arbitrary),
-})
 
 /** @since 1.0.0 */
 export const URI = 'Arbitrary'
@@ -21,11 +9,11 @@ export type URI = typeof URI
 
 declare module 'fp-ts/lib/HKT' {
   interface URItoKind<A> {
-    readonly Arbitrary: Arbitrary<A>
+    readonly Arbitrary: fc.Arbitrary<A>
   }
 }
 
 /** @since 2.0.0 */
 export interface SchemableLambda extends hkt.SchemableLambda {
-  readonly type: Arbitrary<this['Output']>
+  readonly type: fc.Arbitrary<this['Output']>
 }

--- a/src/schemables/array/instances/arbitrary.ts
+++ b/src/schemables/array/instances/arbitrary.ts
@@ -1,23 +1,21 @@
+import * as fc from 'fast-check'
 import * as RA from 'fp-ts/ReadonlyArray'
-import * as Arb from 'schemata-ts/internal/arbitrary'
+import type * as Arb from 'schemata-ts/internal/arbitrary'
 import { type WithArray } from 'schemata-ts/schemables/array/definition'
 
 export const ArrayArbitrary: WithArray<Arb.SchemableLambda> = {
   array: (params = {}) => {
     const { minLength = 0, maxLength = 2 ** 32 - 2 } = params
     return item =>
-      Arb.makeArbitrary(fc =>
-        fc.array(item.arbitrary(fc), {
-          minLength: Math.floor(Math.max(minLength, 0)),
-          maxLength: Math.floor(Math.min(maxLength, 2 ** 32 - 2)),
-        }),
-      )
+      fc.array(item, {
+        minLength: Math.floor(Math.max(minLength, 0)),
+        maxLength: Math.floor(Math.min(maxLength, 2 ** 32 - 2)),
+      })
   },
-  tuple: (...components) =>
-    Arb.makeArbitrary(fc => {
-      if (components.length === 0) {
-        return fc.constant(RA.zero())
-      }
-      return fc.tuple(...components.map(arb => arb.arbitrary(fc))) as any
-    }),
+  tuple: (...components) => {
+    if (components.length === 0) {
+      return fc.constant(RA.zero())
+    }
+    return fc.tuple(...components) as any
+  },
 }

--- a/src/schemables/check-digit/instances/arbitrary.ts
+++ b/src/schemables/check-digit/instances/arbitrary.ts
@@ -1,5 +1,5 @@
 import { type Branded } from 'schemata-ts/brand'
-import * as Arb from 'schemata-ts/internal/arbitrary'
+import type * as Arb from 'schemata-ts/internal/arbitrary'
 import {
   type CheckDigitVerified,
   type WithCheckDigit,
@@ -8,15 +8,11 @@ import { locationToIndex, replaceCharAt } from 'schemata-ts/schemables/check-dig
 
 export const CheckDigitArbitrary: WithCheckDigit<Arb.SchemableLambda> = {
   checkDigit: (algorithm, location) => arb =>
-    Arb.makeArbitrary(fc =>
-      arb
-        .arbitrary(fc)
-        .map(
-          s =>
-            replaceCharAt(s, locationToIndex(s, location), algorithm(s)) as Branded<
-              CheckDigitVerified,
-              CheckDigitVerified
-            >,
-        ),
+    arb.map(
+      s =>
+        replaceCharAt(s, locationToIndex(s, location), algorithm(s)) as Branded<
+          CheckDigitVerified,
+          CheckDigitVerified
+        >,
     ),
 }

--- a/src/schemables/date/instances/arbitrary.ts
+++ b/src/schemables/date/instances/arbitrary.ts
@@ -1,4 +1,5 @@
-import * as Arb from 'schemata-ts/internal/arbitrary'
+import * as fc from 'fast-check'
+import type * as Arb from 'schemata-ts/internal/arbitrary'
 import { type WithDate } from 'schemata-ts/schemables/date/definition'
 import {
   earliestSafeDate,
@@ -9,14 +10,10 @@ import {
 export const DateArbitrary: WithDate<Arb.SchemableLambda> = {
   date: (params = {}) => {
     const { beforeDate = latestSafeDate, afterDate = earliestSafeDate } = params
-    return Arb.makeArbitrary(fc =>
-      fc.date({ min: afterDate, max: beforeDate }).filter(isSafeDate),
-    )
+    return fc.date({ min: afterDate, max: beforeDate }).filter(isSafeDate)
   },
   dateFromString: (params = {}) => {
     const { beforeDate, afterDate } = params
-    return Arb.makeArbitrary(fc =>
-      fc.date({ min: afterDate, max: beforeDate }).filter(isSafeDate),
-    )
+    return fc.date({ min: afterDate, max: beforeDate }).filter(isSafeDate)
   },
 }

--- a/src/schemables/guarded-union/instances/arbitrary.ts
+++ b/src/schemables/guarded-union/instances/arbitrary.ts
@@ -1,6 +1,7 @@
+import * as fc from 'fast-check'
 import { pipe } from 'fp-ts/function'
 import * as RNEA from 'fp-ts/ReadonlyNonEmptyArray'
-import * as Arb from 'schemata-ts/internal/arbitrary'
+import type * as Arb from 'schemata-ts/internal/arbitrary'
 import {
   type WithGuardedUnion,
   ordGuardedPrecedentedUnionMember,
@@ -9,8 +10,6 @@ import {
 export const GuardedUnionArbitrary: WithGuardedUnion<Arb.SchemableLambda> = {
   guardedUnion: (_name, ...members) => {
     const sortedMembers = pipe(members, RNEA.sort(ordGuardedPrecedentedUnionMember))
-    return Arb.makeArbitrary(fc =>
-      fc.oneof(...sortedMembers.map(m => m.member.arbitrary(fc))),
-    )
+    return fc.oneof(...sortedMembers.map(m => m.member))
   },
 }

--- a/src/schemables/invariant/instances/arbitrary.ts
+++ b/src/schemables/invariant/instances/arbitrary.ts
@@ -1,6 +1,6 @@
-import * as Arb from 'schemata-ts/internal/arbitrary'
+import type * as Arb from 'schemata-ts/internal/arbitrary'
 import { type WithInvariant } from 'schemata-ts/schemables/invariant/definition'
 
 export const InvariantArbitrary: WithInvariant<Arb.SchemableLambda> = {
-  imap: () => get => arb => Arb.makeArbitrary(fc => arb.arbitrary(fc).map(get)),
+  imap: () => get => arb => arb.map(get),
 }

--- a/src/schemables/lazy/instances/arbitrary.ts
+++ b/src/schemables/lazy/instances/arbitrary.ts
@@ -1,11 +1,12 @@
+import * as fc from 'fast-check'
 import { type Lazy } from 'fp-ts/function'
-import * as Arb from 'schemata-ts/internal/arbitrary'
+import type * as Arb from 'schemata-ts/internal/arbitrary'
 import { memoize } from 'schemata-ts/Schema'
 import { type WithLazy } from 'schemata-ts/schemables/lazy/definition'
 
 export const LazyArbitrary: WithLazy<Arb.SchemableLambda> = {
-  lazy: <O>(_: string, f: Lazy<Arb.Arbitrary<O>>): Arb.Arbitrary<O> => {
-    const get = memoize<void, Arb.Arbitrary<O>>(f)
-    return Arb.makeArbitrary(fc => fc.constant(null).chain(() => get().arbitrary(fc)))
+  lazy: <O>(_: string, f: Lazy<fc.Arbitrary<O>>): fc.Arbitrary<O> => {
+    const get = memoize<void, fc.Arbitrary<O>>(f)
+    return fc.constant(null).chain(() => get())
   },
 }

--- a/src/schemables/map/instances/arbitrary.ts
+++ b/src/schemables/map/instances/arbitrary.ts
@@ -1,14 +1,11 @@
+import * as fc from 'fast-check'
 import * as RA from 'fp-ts/ReadonlyArray'
 import * as RM from 'fp-ts/ReadonlyMap'
 import * as Sg from 'fp-ts/Semigroup'
-import * as Arb from 'schemata-ts/internal/arbitrary'
+import type * as Arb from 'schemata-ts/internal/arbitrary'
 import { type WithMap } from 'schemata-ts/schemables/map/definition'
 
 export const MapArbitrary: WithMap<Arb.SchemableLambda> = {
   mapFromEntries: (ordK, arbK, arbA) =>
-    Arb.makeArbitrary(fc =>
-      fc
-        .array(fc.tuple(arbK.arbitrary(fc), arbA.arbitrary(fc)))
-        .map(RM.fromFoldable(ordK, Sg.last(), RA.Foldable)),
-    ),
+    fc.array(fc.tuple(arbK, arbA)).map(RM.fromFoldable(ordK, Sg.last(), RA.Foldable)),
 }

--- a/src/schemables/optional/instances/arbitrary.ts
+++ b/src/schemables/optional/instances/arbitrary.ts
@@ -1,10 +1,8 @@
-import * as Arb from 'schemata-ts/internal/arbitrary'
+import * as fc from 'fast-check'
+import type * as Arb from 'schemata-ts/internal/arbitrary'
 import { makeImplicitOptionalType } from 'schemata-ts/internal/struct'
 import { type WithOptional } from 'schemata-ts/schemables/optional/definition'
 
 export const OptionalArbitrary: WithOptional<Arb.SchemableLambda> = {
-  optional: arbA =>
-    makeImplicitOptionalType(
-      Arb.makeArbitrary(fc => fc.oneof(arbA.arbitrary(fc), fc.constant(undefined))),
-    ),
+  optional: arbA => makeImplicitOptionalType(fc.oneof(arbA, fc.constant(undefined))),
 }

--- a/src/schemables/pattern/instances/arbitrary.ts
+++ b/src/schemables/pattern/instances/arbitrary.ts
@@ -3,9 +3,10 @@
  *
  * @since 1.0.0
  */
+import * as fc from 'fast-check'
 import { pipe } from 'fp-ts/function'
 import * as RA from 'fp-ts/ReadonlyArray'
-import * as Arb from 'schemata-ts/internal/arbitrary'
+import type * as Arb from 'schemata-ts/internal/arbitrary'
 import { match, matchOn } from 'schemata-ts/internal/match'
 import type * as PB from 'schemata-ts/PatternBuilder'
 import { type WithPattern } from 'schemata-ts/schemables/pattern/definition'
@@ -13,104 +14,71 @@ import { type WithPattern } from 'schemata-ts/schemables/pattern/definition'
 const matchK = matchOn('kind')
 
 /** @internal */
-export const arbitraryFromAtom: (atom: PB.Atom) => Arb.Arbitrary<string> = matchK({
-  anything: () => Arb.makeArbitrary(fc => fc.char()),
-  character: ({ char }) => Arb.makeArbitrary(fc => fc.constant(char)),
+export const arbitraryFromAtom: (atom: PB.Atom) => fc.Arbitrary<string> = matchK({
+  anything: () => fc.char(),
+  character: ({ char }) => fc.constant(char),
   characterClass: ({ exclude, ranges }) =>
-    Arb.makeArbitrary(fc =>
-      (exclude
-        ? fc
-            .integer({ min: 1, max: 0xffff })
-            .filter(i => ranges.every(({ lower, upper }) => i > upper || i < lower))
-        : fc.oneof(
-            ...ranges.map(({ lower, upper }) => fc.integer({ min: lower, max: upper })),
-          )
-      ).map(charCode => String.fromCharCode(charCode)),
-    ),
+    (exclude
+      ? fc
+          .integer({ min: 1, max: 0xffff })
+          .filter(i => ranges.every(({ lower, upper }) => i > upper || i < lower))
+      : fc.oneof(
+          ...ranges.map(({ lower, upper }) => fc.integer({ min: lower, max: upper })),
+        )
+    ).map(charCode => String.fromCharCode(charCode)),
   subgroup: ({ subpattern }) => arbitraryFromPattern(subpattern),
 })
 
 /** @internal */
 export const arbitraryFromQuantifiedAtom: (
   quantifiedAtom: PB.QuantifiedAtom,
-) => Arb.Arbitrary<string> = matchK({
-  star: ({ atom }) =>
-    Arb.makeArbitrary(fc =>
-      fc.array(arbitraryFromAtom(atom).arbitrary(fc)).map(strs => strs.join('')),
-    ),
+) => fc.Arbitrary<string> = matchK({
+  star: ({ atom }) => fc.array(arbitraryFromAtom(atom)).map(strs => strs.join('')),
   plus: ({ atom }) =>
-    Arb.makeArbitrary(fc =>
-      fc
-        .array(arbitraryFromAtom(atom).arbitrary(fc), { minLength: 1 })
-        .map(strs => strs.join('')),
-    ),
+    fc.array(arbitraryFromAtom(atom), { minLength: 1 }).map(strs => strs.join('')),
   question: ({ atom }) =>
-    Arb.makeArbitrary(fc =>
-      fc
-        .array(arbitraryFromAtom(atom).arbitrary(fc), { minLength: 0, maxLength: 1 })
-        .map(strs => strs.join('')),
-    ),
+    fc
+      .array(arbitraryFromAtom(atom), { minLength: 0, maxLength: 1 })
+      .map(strs => strs.join('')),
   exactly: ({ atom, count }) =>
-    Arb.makeArbitrary(fc =>
-      fc
-        .array(arbitraryFromAtom(atom).arbitrary(fc), {
-          minLength: count,
-          maxLength: count,
-        })
-        .map(strs => strs.join('')),
-    ),
+    fc
+      .array(arbitraryFromAtom(atom), {
+        minLength: count,
+        maxLength: count,
+      })
+      .map(strs => strs.join('')),
   between: ({ atom, min, max }) =>
-    Arb.makeArbitrary(fc =>
-      fc
-        .array(arbitraryFromAtom(atom).arbitrary(fc), { minLength: min, maxLength: max })
-        .map(strs => strs.join('')),
-    ),
+    fc
+      .array(arbitraryFromAtom(atom), { minLength: min, maxLength: max })
+      .map(strs => strs.join('')),
   minimum: ({ atom, min }) =>
-    Arb.makeArbitrary(fc =>
-      fc
-        .array(arbitraryFromAtom(atom).arbitrary(fc), { minLength: min })
-        .map(strs => strs.join('')),
-    ),
+    fc.array(arbitraryFromAtom(atom), { minLength: min }).map(strs => strs.join('')),
 })
 
-const arbitraryFromTerm: (term: PB.Term) => Arb.Arbitrary<string> = match({
+const arbitraryFromTerm: (term: PB.Term) => fc.Arbitrary<string> = match({
   atom: arbitraryFromAtom,
   quantifiedAtom: arbitraryFromQuantifiedAtom,
 })
 
-const chainConcatAll: (
-  fcs: ReadonlyArray<Arb.Arbitrary<string>>,
-) => Arb.Arbitrary<string> = RA.foldLeft(
-  () => Arb.makeArbitrary(fc => fc.constant('')),
-  (head, tail) =>
-    Arb.makeArbitrary(fc =>
-      head.arbitrary(fc).chain(headStr =>
-        chainConcatAll(tail)
-          .arbitrary(fc)
-          .map(tailStr => headStr + tailStr),
-      ),
-    ),
-)
+const chainConcatAll: (fcs: ReadonlyArray<fc.Arbitrary<string>>) => fc.Arbitrary<string> =
+  RA.foldLeft(
+    () => fc.constant(''),
+    (head, tail) =>
+      head.chain(headStr => chainConcatAll(tail).map(tailStr => headStr + tailStr)),
+  )
 
 /**
  * Construct a `fast-check` `Arbitrary` instance from a given `Pattern`.
  *
  * @since 1.0.0
  */
-export const arbitraryFromPattern: (pattern: PB.Pattern) => Arb.Arbitrary<string> = match(
-  {
-    atom: arbitraryFromAtom,
-    disjunction: ({ left, right }) =>
-      Arb.makeArbitrary(fc =>
-        fc.oneof(
-          arbitraryFromPattern(left).arbitrary(fc),
-          arbitraryFromPattern(right).arbitrary(fc),
-        ),
-      ),
-    quantifiedAtom: arbitraryFromQuantifiedAtom,
-    termSequence: ({ terms }) => pipe(terms.map(arbitraryFromTerm), chainConcatAll),
-  },
-)
+export const arbitraryFromPattern: (pattern: PB.Pattern) => fc.Arbitrary<string> = match({
+  atom: arbitraryFromAtom,
+  disjunction: ({ left, right }) =>
+    fc.oneof(arbitraryFromPattern(left), arbitraryFromPattern(right)),
+  quantifiedAtom: arbitraryFromQuantifiedAtom,
+  termSequence: ({ terms }) => pipe(terms.map(arbitraryFromTerm), chainConcatAll),
+})
 
 /**
  * @since 1.0.0

--- a/src/schemables/primitives/instances/arbitrary.ts
+++ b/src/schemables/primitives/instances/arbitrary.ts
@@ -1,44 +1,38 @@
-import * as Arb from 'schemata-ts/internal/arbitrary'
+import * as fc from 'fast-check'
+import type * as Arb from 'schemata-ts/internal/arbitrary'
 import { type WithPrimitives } from 'schemata-ts/schemables/primitives/definition'
 import { isFloat, isInt } from 'schemata-ts/schemables/primitives/utils'
 
 /** @since 2.0.0 */
 export const PrimitivesArbitrary: WithPrimitives<Arb.SchemableLambda> = {
   string: params =>
-    Arb.makeArbitrary(fc =>
-      fc.oneof(
-        fc.string(params),
-        fc.asciiString(params),
-        fc.hexaString(params),
-        fc.base64String(params),
-      ),
+    fc.oneof(
+      fc.string(params),
+      fc.asciiString(params),
+      fc.hexaString(params),
+      fc.base64String(params),
     ),
   int: (params = {}) => {
     const { min = Number.MIN_SAFE_INTEGER, max = Number.MAX_SAFE_INTEGER } = params
-    return Arb.makeArbitrary(fc =>
-      fc
-        .integer({
-          min: Math.floor(Math.max(min, Number.MIN_SAFE_INTEGER)),
-          max: Math.floor(Math.min(max, Number.MAX_SAFE_INTEGER)),
-        })
-        .filter(isInt(params)),
-    )
+    return fc
+      .integer({
+        min: Math.floor(Math.max(min, Number.MIN_SAFE_INTEGER)),
+        max: Math.floor(Math.min(max, Number.MAX_SAFE_INTEGER)),
+      })
+      .filter(isInt(params))
   },
   float(params = {}) {
     const { min = -Number.MAX_VALUE, max = Number.MAX_VALUE } = params
-    return Arb.makeArbitrary(fc =>
-      fc
-        .double({
-          min,
-          max,
-          noDefaultInfinity: true,
-          noNaN: true,
-        })
-        .filter(isFloat(params)),
-    )
+    return fc
+      .double({
+        min,
+        max,
+        noDefaultInfinity: true,
+        noNaN: true,
+      })
+      .filter(isFloat(params))
   },
-  boolean: Arb.makeArbitrary(fc => fc.boolean()),
-  unknown: Arb.makeArbitrary(fc => fc.anything()),
-  literal: (...literals) =>
-    Arb.makeArbitrary(fc => fc.oneof(...literals.map(v => fc.constant(v)))),
+  boolean: fc.boolean(),
+  unknown: fc.anything(),
+  literal: (...literals) => fc.oneof(...literals.map(v => fc.constant(v))),
 }

--- a/src/schemables/refine/instances/arbitrary.ts
+++ b/src/schemables/refine/instances/arbitrary.ts
@@ -1,7 +1,6 @@
-import * as Arb from 'schemata-ts/internal/arbitrary'
+import type * as Arb from 'schemata-ts/internal/arbitrary'
 import { type WithRefine } from 'schemata-ts/schemables/refine/definition'
 
 export const RefineArbitrary: WithRefine<Arb.SchemableLambda> = {
-  refine: refinement => from =>
-    Arb.makeArbitrary(fc => from.arbitrary(fc).filter(refinement)),
+  refine: refinement => from => from.filter(refinement),
 }

--- a/src/schemables/struct/instances/arbitrary.ts
+++ b/src/schemables/struct/instances/arbitrary.ts
@@ -1,5 +1,6 @@
+import * as fc from 'fast-check'
 import { identity } from 'fp-ts/function'
-import * as Arb from 'schemata-ts/internal/arbitrary'
+import type * as Arb from 'schemata-ts/internal/arbitrary'
 import { type WithStruct } from 'schemata-ts/schemables/struct/definition'
 import { remapPropertyKeys, safeIntersect } from 'schemata-ts/schemables/struct/utils'
 
@@ -9,7 +10,7 @@ export const StructArbitrary: WithStruct<Arb.SchemableLambda> = {
   struct: properties => {
     const lookupByOutputKey = remapPropertyKeys(properties, i => 1 / i)
 
-    const collapsedArbs: Record<string, Arb.Arbitrary<unknown>> = {}
+    const collapsedArbs: Record<string, fc.Arbitrary<unknown>> = {}
 
     for (const key in lookupByOutputKey) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -17,34 +18,24 @@ export const StructArbitrary: WithStruct<Arb.SchemableLambda> = {
 
       collapsedArbs[key] =
         arbs.length === 1
-          ? Arb.makeArbitrary(fc => arbs[0].member.arbitrary(fc))
-          : Arb.makeArbitrary(fc =>
-              fc.oneof(
-                ...arbs.map(({ member, precedence }) => ({
-                  arbitrary: member.arbitrary(fc),
-                  weight: precedence,
-                })),
-              ),
+          ? arbs[0].member
+          : fc.oneof(
+              ...arbs.map(({ member, precedence }) => ({
+                arbitrary: member,
+                weight: precedence,
+              })),
             )
     }
 
-    return Arb.makeArbitrary(fc => {
-      const out = {} as any
-      for (const key in collapsedArbs) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const arb = collapsedArbs[key]!
-        out[key] = arb.arbitrary(fc)
-      }
+    const out = {} as any
+    for (const key in collapsedArbs) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      out[key] = collapsedArbs[key]!
+    }
 
-      return fc.record(out) as any
-    })
+    return fc.record(out) as any
   },
-  record: (key, codomain) =>
-    Arb.makeArbitrary(fc =>
-      fc.dictionary(key.arbitrary(fc), codomain.arbitrary(fc)).map(readonly),
-    ),
-  intersection: (xs, ys) =>
-    Arb.makeArbitrary(fc =>
-      fc.tuple(xs.arbitrary(fc), ys.arbitrary(fc)).map(([x, y]) => safeIntersect(x, y)),
-    ),
+
+  record: (key, codomain) => fc.dictionary(key, codomain).map(readonly),
+  intersection: (xs, ys) => fc.tuple(xs, ys).map(([x, y]) => safeIntersect(x, y)),
 }

--- a/test-utils/test-suite.ts
+++ b/test-utils/test-suite.ts
@@ -284,7 +284,7 @@ export const getTestSuite = <I, O>(schema: Schema<I, O>): TestSuite<I, O> => {
       })
     },
     validateJsonSchemas: () => {
-      const arbitrary = getArbitrary(schema).arbitrary(fc)
+      const arbitrary = getArbitrary(schema)
       const draft2007 = new Draft07(jsonSchema2007)
       test('Draft-2007', () => {
         fc.assert(
@@ -302,7 +302,7 @@ export const getTestSuite = <I, O>(schema: Schema<I, O>): TestSuite<I, O> => {
       })
     },
     testTranscoderLaws: () => {
-      const arbitrary = getArbitrary(schema).arbitrary(fc)
+      const arbitrary = getArbitrary(schema)
       describe('idempotence', () => {
         test('sequential', () => {
           fc.assert(
@@ -325,7 +325,7 @@ export const getTestSuite = <I, O>(schema: Schema<I, O>): TestSuite<I, O> => {
           )
         })
         test('parallel', async () => {
-          const arbitrary = getArbitrary(schema).arbitrary(fc)
+          const arbitrary = getArbitrary(schema)
           fc.assert(
             fc.asyncProperty(arbitrary, async output => {
               const initial = pipe(
@@ -352,7 +352,7 @@ export const getTestSuite = <I, O>(schema: Schema<I, O>): TestSuite<I, O> => {
       })
     },
     testSemigroupLaws: () => {
-      const arbitrary = getArbitrary(schema).arbitrary(fc)
+      const arbitrary = getArbitrary(schema)
       describe('associativity', () => {
         test('firstSemigroup', () => {
           fc.assert(
@@ -384,7 +384,7 @@ export const getTestSuite = <I, O>(schema: Schema<I, O>): TestSuite<I, O> => {
       })
     },
     testEqLaws: () => {
-      const arbitrary = getArbitrary(schema).arbitrary(fc)
+      const arbitrary = getArbitrary(schema)
       test('reflexivity', () => {
         fc.assert(
           fc.property(arbitrary, output => {
@@ -410,7 +410,7 @@ export const getTestSuite = <I, O>(schema: Schema<I, O>): TestSuite<I, O> => {
       })
     },
     testArbitraryGuard: () => {
-      const arbitrary = getArbitrary(schema).arbitrary(fc)
+      const arbitrary = getArbitrary(schema)
       test('arbitraries', () => {
         fc.assert(
           fc.property(arbitrary, output => {


### PR DESCRIPTION
This removes the `{ arbitrary: (fc) => }` wrapper. It really shouldn't be necessary if we're careful with exports. `kuvio` for example isolates the `Arbitrary` stuff, though admittedly it's a bit simpler in that lib: https://github.com/skeate/kuvio/blob/main/package.json#L20-L26

I believe, however, that `schemata-ts` is already structured properly. The only references to `Arbitrary` I saw with a quick search in `src/` were either (1) related to arbitraries or (2) in `Schema.ts` in the comments